### PR TITLE
Added settings description for manual servers

### DIFF
--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -258,6 +258,31 @@
     ]
   },
   {
+    "section": "manualServers",
+    "values": [
+      {
+        "value": "ip1",
+        "default": "",
+        "input_type": "ip"
+      },
+      {
+        "value": "port1",
+        "default": 32400,
+        "input_type": "port"
+      },
+      {
+        "value": "ip2",
+        "default": "",
+        "input_type": "ip"
+      },
+      {
+        "value": "port2",
+        "default": 32400,
+        "input_type": "port"
+      }
+    ]
+  },
+  {
     "section": "path",
     "hidden": true,
     "values": [


### PR DESCRIPTION
_This still needs some C++ side which I'm lost at, right now the value of `inputType` isn't being returned to the JS code. Would someone more familiar with the code take a look and see if they can make the required changes. Thanks!_

pretty simple change, this adds config description for manual servers so we can enable them for PMP.