### PR TITLE
Switch manual server port from int to string

### DIFF
--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -283,7 +283,7 @@
       },
       {
         "value": "port1",
-        "default": 32400,
+        "default": "32400",
         "input_type": "port"
       },
       {
@@ -293,7 +293,7 @@
       },
       {
         "value": "port2",
-        "default": 32400,
+        "default": "32400",
         "input_type": "port"
       }
     ]


### PR DESCRIPTION
_I know this is a small fix, but wanted to make sure someone takes a look to make sure it won't blow up the world if I change the type of an attribute_


Recent web refactoring enforces certain attribute types, we've always been storing the value as string, so existing data should be fine, this change will just update the default value returned by konvergo to be string rather than int.

https://github.com/plexinc/plex-web-client/blob/all-abstract-server/app/js/plex/base/models/server/ConnectionModel.js#L57

