### PR TITLE
Don't use a property binding on WebEngineView.url

### DIFF
--- a/src/ui/webview.qml
+++ b/src/ui/webview.qml
@@ -40,7 +40,6 @@ KonvergoWindow
     settings.errorPageEnabled: false
     settings.localContentCanAccessRemoteUrls: true
     profile.httpUserAgent: components.system.getUserAgent()
-    url: components.settings.value("path", "startupurl") + getMaxHeightArg()
     transformOrigin: Item.TopLeft
 
     width: Math.min((parent.height * 16) / 9, parent.width)
@@ -85,6 +84,8 @@ KonvergoWindow
       backgroundColor : "#111111"
       forceActiveFocus()
       mainWindow.reloadWebClient.connect(reload)
+
+      url = components.settings.value("path", "startupurl") + getMaxHeightArg()
     }
 
     onLoadingChanged:


### PR DESCRIPTION
QQuickWebEngineView::setUrl has a particular behavior vs other QML
properties that it doesn't check if the value is the same before
applying a new binding result. This means that if any of the binding
dependency changes ("Screen" in this case), the page will reload.

Since we always ever only want to set the URL once, set the url
property imperatively in Component.onCompleted. This however means
that the maxHeight query parameter will be wrong if the window
is later switched to a screen that would provide a different height.

This should help for #163 and possibly #155.