### PR TITLE
Add keyboard mapping for toggling watch status.

### DIFF
--- a/resources/inputmaps/keyboard.json
+++ b/resources/inputmaps/keyboard.json
@@ -49,6 +49,7 @@
 
     // emulate some of of PHT's behaviour
     "I": "host:toggleDebug",
+    "W": "toggle_watched",
     "\\\\": "host:fullscreen",
 
     // media keys from the FLIRC and on Linux keyboards


### PR DESCRIPTION
This allows toggling watched statuses for video items using the keyboard `w` key.

Season or show items will ask for confirmation before being toggled, single items will have no confirmation.