### PR TITLE
Don't require the GUI thread's assistance to render video

### DIFF
--- a/src/player/PlayerQuickItem.cpp
+++ b/src/player/PlayerQuickItem.cpp
@@ -217,12 +217,13 @@ void PlayerRenderer::on_update(void *ctx)
 {
   PlayerRenderer *self = (PlayerRenderer *)ctx;
   // QQuickWindow::scheduleRenderJob is expected to be called from the GUI thread but
-  // is thread-safe when using the QSGThreadedRenderLoop, which we can detect by checking
-  // if QQuickWindow::beforeSynchronizing wasn't called from the GUI thread.
-  if (self->thread() != self->m_window->thread())
-    self->m_window->scheduleRenderJob(new RequestRepaintJob(self->m_window), QQuickWindow::NoStage);
-  else
+  // is thread-safe when using the QSGThreadedRenderLoop. We can detect a non-threaded render
+  // loop by checking if QQuickWindow::beforeSynchronizing was called from the GUI thread
+  // (which affects the QObject::thread() of the PlayerRenderer).
+  if (self->thread() == self->m_window->thread())
     QMetaObject::invokeMethod(self->m_window, "update", Qt::QueuedConnection);
+  else
+    self->m_window->scheduleRenderJob(new RequestRepaintJob(self->m_window), QQuickWindow::NoStage);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/player/PlayerQuickItem.cpp
+++ b/src/player/PlayerQuickItem.cpp
@@ -3,6 +3,7 @@
 #include <stdexcept>
 
 #include <QOpenGLContext>
+#include <QRunnable>
 
 #include <QtGui/QOpenGLFramebufferObject>
 
@@ -125,6 +126,24 @@ static void* get_proc_address(void* ctx, const char* name)
   return res;
 }
 
+namespace {
+
+class RequestRepaintJob : public QRunnable {
+  QQuickWindow *window;
+public:
+  RequestRepaintJob(QQuickWindow *window) : window(window) { }
+  void run() override {
+    // QSGThreadedRenderLoop::update has a special code path that will render
+    // without syncing the render and GUI threads unless asked elsewhere to support
+    // QQuickAnimator animations. This is currently triggered by the fact that
+    // QQuickWindow::update() is called from the render thread.
+    // This allows continuing rendering video while the GUI thread is busy.
+    window->update();
+  }
+};
+
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 PlayerRenderer::PlayerRenderer(mpv::qt::Handle mpv, QQuickWindow* window)
 : m_mpv(mpv), m_mpvGL(0), m_window(window), m_size(), m_hAvrtHandle(0)
@@ -139,6 +158,8 @@ bool PlayerRenderer::init()
   // Request Multimedia Class Schedule Service.
   DwmEnableMMCSS(TRUE);
 #endif
+
+  mpv_opengl_cb_set_update_callback(m_mpvGL, on_update, (void *)this);
 
   // Signals presence of MPGetNativeDisplay().
   const char *extensions = "GL_MP_MPGetNativeDisplay";
@@ -192,6 +213,19 @@ void PlayerRenderer::onPlaybackActive(bool active)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+void PlayerRenderer::on_update(void *ctx)
+{
+  PlayerRenderer *self = (PlayerRenderer *)ctx;
+  // QQuickWindow::scheduleRenderJob is expected to be called from the GUI thread but
+  // is thread-safe when using the QSGThreadedRenderLoop, which we can detect by checking
+  // if QQuickWindow::beforeSynchronizing wasn't called from the GUI thread.
+  if (self->thread() != self->m_window->thread())
+    self->m_window->scheduleRenderJob(new RequestRepaintJob(self->m_window), QQuickWindow::NoStage);
+  else
+    QMetaObject::invokeMethod(self->m_window, "update", Qt::QueuedConnection);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 PlayerQuickItem::PlayerQuickItem(QQuickItem* parent)
 : QQuickItem(parent), m_mpvGL(NULL), m_renderer(NULL)
 {
@@ -213,7 +247,6 @@ void PlayerQuickItem::onWindowChanged(QQuickWindow* win)
   {
     connect(win, &QQuickWindow::beforeSynchronizing, this, &PlayerQuickItem::onSynchronize, Qt::DirectConnection);
     connect(win, &QQuickWindow::sceneGraphInvalidated, this, &PlayerQuickItem::onInvalidate, Qt::DirectConnection);
-    connect(this, &PlayerQuickItem::onUpdate, win, &QQuickWindow::update, Qt::QueuedConnection);
   }
 }
 
@@ -270,13 +303,6 @@ void PlayerQuickItem::onInvalidate()
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
-void PlayerQuickItem::on_update(void *ctx)
-{
-  PlayerQuickItem *self = (PlayerQuickItem *)ctx;
-  emit self->onUpdate();
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
 void PlayerQuickItem::initMpv(PlayerComponent* player)
 {
   m_mpv = player->getMpvHandle();
@@ -284,8 +310,6 @@ void PlayerQuickItem::initMpv(PlayerComponent* player)
   m_mpvGL = (mpv_opengl_cb_context *)mpv_get_sub_api(m_mpv, MPV_SUB_API_OPENGL_CB);
   if (!m_mpvGL)
     throw FatalException(tr("OpenGL not enabled in libmpv."));
-
-  mpv_opengl_cb_set_update_callback(m_mpvGL, on_update, (void *)this);
 
   connect(player, &PlayerComponent::windowVisible, this, &QQuickItem::setVisible);
   window()->update();

--- a/src/player/PlayerQuickItem.h
+++ b/src/player/PlayerQuickItem.h
@@ -31,6 +31,7 @@ public slots:
   void onPlaybackActive(bool active);
 
 private:
+  static void on_update(void *ctx);
   mpv::qt::Handle m_mpv;
   mpv_opengl_cb_context* m_mpvGL;
   QQuickWindow* m_window;
@@ -50,7 +51,6 @@ public:
     QString debugInfo() { return m_debugInfo; }
 
 signals:
-    void onUpdate();
     void onFatalError(QString message);
 
 private slots:
@@ -60,7 +60,6 @@ private slots:
     void onHandleFatalError(QString message);
 
 private:
-    static void on_update(void *ctx);
     mpv::qt::Handle m_mpv;
     mpv_opengl_cb_context* m_mpvGL;
     PlayerRenderer* m_renderer;


### PR DESCRIPTION
Tested using QT_LOGGING_RULES="qt.scenegraph.renderloop=true"

Before:
```
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "update on window KonvergoWindow_QML_0(0x7f9a71ec9ef0, name=\"mainWindow\")" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "update from item KonvergoWindow_QML_0(0x7f9a71ec9ef0, name=\"mainWindow\")" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "- polish and sync update request" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "polishAndSync (normal) KonvergoWindow_QML_0(0x7f9a71ec9ef0, name=\"mainWindow\")" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "- lock for sync" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "- wait for sync" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) --- begin processEvents()" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) WM_RequestSync" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - repaint regardless" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) --- done processEvents()" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) syncAndRender()" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - updatePending, doing sync" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) sync()" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - sync complete, waking Gui" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - rendering started" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "- unlock after sync" 
2016-03-16 12:24:35 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - rendering done" 
```

After:
```
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "                    (RT) --- begin processEvents()" 
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "                    (RT) WM_PostJob" 
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "update on window - on render thread KonvergoWindow_QML_0(0x7fc4e94d7930, name=\"mainWindow\")" 
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - job done" 
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "                    (RT) --- done processEvents()" 
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "                    (RT) syncAndRender()" 
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - rendering started" 
2016-03-16 12:15:04 [ DEBUG ] Log.cpp @ 29 - "                    (RT) - rendering done" 
```