### PR TITLE
Replace the Qt foreach macro with C++11 for style loops

### DIFF
--- a/src/ComponentManager.cpp
+++ b/src/ComponentManager.cpp
@@ -74,14 +74,14 @@ void ComponentManager::initialize()
   registerComponent(&OESystemComponent::Get());
 #endif
 
-  foreach(ComponentBase* component, m_components.values())
+  for(ComponentBase* component : m_components.values())
     component->componentPostInitialize();
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
 void ComponentManager::setWebChannel(QWebChannel* webChannel)
 {
-  foreach(ComponentBase* comp, m_components.values())
+  for(ComponentBase* comp : m_components.values())
   {
     if (comp->componentExport())
     {

--- a/src/display/DisplayComponent.cpp
+++ b/src/display/DisplayComponent.cpp
@@ -69,7 +69,7 @@ bool DisplayComponent::componentInitialize()
     connect(app, SIGNAL(screenAdded(QScreen*)), this, SLOT(monitorChange()));
     connect(app, SIGNAL(screenRemoved(QScreen*)), this,  SLOT(monitorChange()));
 
-    foreach (QScreen *screen, app->screens())
+    for(QScreen *screen : app->screens())
     {
       connect(screen, SIGNAL(refreshRateChanged(qreal)), this, SLOT(monitorChange()));
       connect(screen, SIGNAL(geometryChanged(QRect)), this, SLOT(monitorChange()));
@@ -352,7 +352,7 @@ void DisplayComponent::switchCommand(QString command)
   DMVideoMode mode = currentMode;
   int bestMode = -1; // if -1, select it by using the mode variable above
 
-  foreach (QString a, command.split(" "))
+  for(QString a : command.split(" "))
   {
     a = a.trimmed();
     if (a == "p")
@@ -402,7 +402,7 @@ void DisplayComponent::switchCommand(QString command)
   {
     QLOG_INFO() << "Mode requested by command:" << mode.getPrettyName();
 
-    foreach (auto cur, m_displayManager->m_displays[currentDisplay]->m_videoModes)
+    for(auto cur : m_displayManager->m_displays[currentDisplay]->m_videoModes)
     {
       // "Score" according to what was requested
       float dCur = modeDistance(*cur, mode);

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -19,7 +19,7 @@ bool DisplayManager::initialize()
   QLOG_INFO() << QString("DisplayManager found %1 Display(s).").arg(m_displays.size());
 
   // list video modes
-  foreach(int displayid, m_displays.keys())
+  for(int displayid : m_displays.keys())
   {
     DMDisplayPtr display = m_displays[displayid];
     QLOG_INFO() << QString("Available modes for Display #%1 (%2)").arg(displayid).arg(display->m_name);
@@ -182,7 +182,7 @@ int DisplayManager::findBestMode(int display)
 {
   int bestMode = -1;
 
-  foreach (auto mode, m_displays[display]->m_videoModes)
+  for(auto mode : m_displays[display]->m_videoModes)
   {
     if (bestMode < 0)
     {

--- a/src/display/win/DisplayManagerWin.cpp
+++ b/src/display/win/DisplayManagerWin.cpp
@@ -174,7 +174,7 @@ DisplayManagerWin::~DisplayManagerWin()
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 int DisplayManagerWin::getDisplayFromPoint(int x, int y)
 {
-  foreach (int displayId, m_displays.keys())
+  for(int displayId : m_displays.keys())
   {
     QString dispName = m_displayAdapters[displayId];
 

--- a/src/display/x11/DisplayManagerX11.cpp
+++ b/src/display/x11/DisplayManagerX11.cpp
@@ -134,7 +134,7 @@ int DisplayManagerX11::getCurrentDisplayMode(int display)
   if (!crtc)
     goto done;
 
-  foreach (DMVideoModePtr mode, displayptr->m_videoModes)
+  for(DMVideoModePtr mode : displayptr->m_videoModes)
   {
     XRRModeInfo m = resources->modes[mode->m_privId];
     if (crtc->mode == m.id)

--- a/src/input/InputMapping.cpp
+++ b/src/input/InputMapping.cpp
@@ -145,7 +145,7 @@ bool InputMapping::loadMappingDirectory(const QString& path, bool copy)
           // get the input map and add it to a new CachedMatcher
           QVariantMap inputMap = mapping.second.value("mapping").toMap();
           auto  inputMatcher = new CachedRegexMatcher(this);
-          foreach(const QString& pattern, inputMap.keys())
+          for(const QString& pattern : inputMap.keys())
             inputMatcher->addMatcher("^" + pattern + "$", inputMap.value(pattern));
 
           m_inputMatcher.insert(mapping.first, inputMatcher);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -59,7 +59,7 @@ char** appendCommandLineArguments(int argc, char **argv, const QStringList& args
   memcpy(newArgv, argv, (size_t)(argc * sizeof(char*)));
 
   int pos = argc;
-  foreach(const QString& str, args)
+  for(const QString& str : args)
     newArgv[pos++] = qstrdup(str.toUtf8().data());
 
   return newArgv;

--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -668,7 +668,7 @@ void PlayerComponent::updateAudioDeviceList()
   QVariantList settingList;
   QVariant list = getAudioDeviceList();
   QSet<QString> devices;
-  foreach (const QVariant& d, list.toList())
+  for(const QVariant& d : list.toList())
   {
     Q_ASSERT(d.type() == QVariant::Map);
     QVariantMap dmap = d.toMap();
@@ -729,7 +729,7 @@ void PlayerComponent::setAudioConfiguration()
     else if (deviceType == AUDIO_DEVICE_TYPE_HDMI && audioSection->value("advanced").toBool())
       codecs = AudioCodecsAll();
 
-    foreach (const QString& key, codecs)
+    for(const QString& key : codecs)
     {
       if (audioSection->value("passthrough." + key).toBool())
         enabledCodecs << key;

--- a/src/remote/GDMManager.cpp
+++ b/src/remote/GDMManager.cpp
@@ -69,7 +69,7 @@ QByteArray GDMManager::getPacket()
 
   QVariantMap headers = RemoteComponent::GDMInformation();
 
-  foreach (const QString& key, headers.keys())
+  for(const QString& key : headers.keys())
     packetData.append(key + ": " + headers[key].toString() + "\r\n");
 
   // terminate header

--- a/src/remote/RemoteComponent.cpp
+++ b/src/remote/RemoteComponent.cpp
@@ -58,7 +58,7 @@ QVariantMap RemoteComponent::HeaderInformation()
   QVariantMap gdmInfo = GDMInformation();
   QVariantMap headerInfo;
 
-  foreach (const QString& key, gdmInfo.keys())
+  for(const QString& key : gdmInfo.keys())
   {
     if (g_headerKeyMap.contains(key))
       headerInfo[g_headerKeyMap[key]] = gdmInfo[key];
@@ -76,7 +76,7 @@ QVariantMap RemoteComponent::ResourceInformation()
   QVariantMap gdmInfo = GDMInformation();
   QVariantMap resourceInfo;
 
-  foreach (const QString& key, gdmInfo.keys())
+  for(const QString& key : gdmInfo.keys())
   {
     if (g_resourceKeyMap.contains(key))
       resourceInfo[g_resourceKeyMap[key]] = gdmInfo[key];
@@ -120,7 +120,7 @@ void RemoteComponent::handleResource(QHttpRequest* request, QHttpResponse* respo
     output.writeStartElement("MediaContainer");
     output.writeStartElement("Player");
 
-    foreach (const QString& key, headers.keys())
+    for(const QString& key : headers.keys())
       output.writeAttribute(key, headers[key].toString());
 
     output.writeEndElement();
@@ -143,9 +143,7 @@ QVariantMap RemoteComponent::QueryToMap(const QUrl& url)
   QUrlQuery query(url);
   QVariantMap queryMap;
 
-  QPair<QString, QString> stringPair;
-
-  foreach (stringPair, query.queryItems())
+  for(auto stringPair : query.queryItems())
   {
     QString key = stringPair.first;
     QString value = stringPair.second;
@@ -170,7 +168,7 @@ QVariantMap RemoteComponent::QueryToMap(const QUrl& url)
 QVariantMap RemoteComponent::HeaderToMap(const qhttp::THeaderHash& hash)
 {
   QVariantMap variantMap;
-  foreach (const QString& key, hash.keys())
+  for(const QString& key : hash.keys())
     variantMap.insert(key, hash.value(key.toUtf8()));
   return variantMap;
 }
@@ -294,7 +292,7 @@ void RemoteComponent::responseDone()
     QMutexLocker lk(&m_responseLock);
 
     int foundId = -1;
-    foreach(int responseId, m_responseMap.keys())
+    for(int responseId : m_responseMap.keys())
     {
       if (m_responseMap[responseId] == response)
       {
@@ -338,7 +336,7 @@ void RemoteComponent::commandResponse(const QVariantMap& responseArguments)
   if (responseArguments.contains("headers") && responseArguments["headers"].type() == QVariant::Map)
   {
     QVariantMap headers = responseArguments["headers"].toMap();
-      foreach (const QString& key, headers.keys())
+      for(const QString& key : headers.keys())
         response->addHeader(key.toUtf8(), headers[key].toByteArray());
   }
 
@@ -448,7 +446,7 @@ void RemoteComponent::checkSubscribers()
 {
   QMutexLocker lk(&m_subscriberLock);
   QList<RemoteSubscriber*> subsToRemove;
-  foreach(RemoteSubscriber* subscriber, m_subscriberMap.values())
+  for(RemoteSubscriber* subscriber : m_subscriberMap.values())
   {
     // was it more than 10 seconds since this client checked in last?
     if (subscriber->lastSubscribe() > 90 * 1000)
@@ -460,7 +458,7 @@ void RemoteComponent::checkSubscribers()
 
   lk.unlock();
 
-  foreach(RemoteSubscriber* sub, subsToRemove)
+  for(RemoteSubscriber* sub : subsToRemove)
     subscriberRemove(sub->clientIdentifier());
 }
 
@@ -522,7 +520,7 @@ void RemoteComponent::timelineUpdate(quint64 commandID, const QString& timeline)
 {
   QMutexLocker lk(&m_subscriberLock);
 
-  foreach (RemoteSubscriber* subscriber, m_subscriberMap.values())
+  for(RemoteSubscriber* subscriber : m_subscriberMap.values())
   {
     subscriber->queueTimeline(commandID, timeline.toUtf8());
     subscriber->sendUpdate();

--- a/src/remote/RemoteSubscriber.cpp
+++ b/src/remote/RemoteSubscriber.cpp
@@ -62,7 +62,7 @@ void RemoteSubscriber::sendUpdate()
   request.setAttribute(QNetworkRequest::User, m_clientIdentifier);
 
   QVariantMap headers = RemoteComponent::HeaderInformation();
-  foreach (const QString& key, headers.keys())
+  for(const QString& key : headers.keys())
   {
     request.setRawHeader(key.toUtf8(), headers[key].toString().toUtf8());
   }

--- a/src/settings/AudioSettingsController.cpp
+++ b/src/settings/AudioSettingsController.cpp
@@ -18,7 +18,7 @@ AudioSettingsController::AudioSettingsController(QObject* parent) : QObject(pare
 void AudioSettingsController::setHiddenPassthrough(const QStringList& codecs, bool hidden)
 {
   SettingsSection* audioSection = SettingsComponent::Get().getSection(SETTINGS_SECTION_AUDIO);
-  foreach(const QString& codec, codecs)
+  for(const QString& codec : codecs)
     audioSection->setValueHidden("passthrough." + codec, hidden);
 }
 

--- a/src/settings/SettingsComponent.cpp
+++ b/src/settings/SettingsComponent.cpp
@@ -49,7 +49,7 @@ QVariant SettingsComponent::allValues(const QString& section)
   if (section.isEmpty())
   {
     QVariantMap all;
-    foreach (const QString& sname, m_sections.keys())
+    for(const QString& sname : m_sections.keys())
       all[sname] = m_sections[sname]->allValues();
     return all;
   }
@@ -139,7 +139,7 @@ void SettingsComponent::loadConf(const QString& path, bool storage)
 
   QJsonObject jsonSections = json["sections"].toObject();
 
-  foreach (const QString& section, jsonSections.keys())
+  for(const QString& section : jsonSections.keys())
   {
     QJsonObject jsonSection = jsonSections[section].toObject();
 
@@ -157,7 +157,7 @@ void SettingsComponent::loadConf(const QString& path, bool storage)
       continue;
     }
 
-    foreach (const QString& setting, jsonSection.keys())
+    for(const QString& setting : jsonSection.keys())
       sec->setValue(setting, jsonSection.value(setting).toVariant());
   }
 }
@@ -167,7 +167,7 @@ void SettingsComponent::saveSettings()
 {
   QVariantMap sections;
 
-  foreach(SettingsSection* section, m_sections.values())
+  for(SettingsSection* section : m_sections.values())
   {
     if (!section->isStorage())
       sections.insert(section->sectionName(), section->allValues());
@@ -184,7 +184,7 @@ void SettingsComponent::saveStorage()
 {
   QVariantMap storage;
 
-  foreach(SettingsSection* section, m_sections.values())
+  for(SettingsSection* section : m_sections.values())
   {
     if (section->isStorage())
       storage.insert(section->sectionName(), section->allValues());
@@ -296,7 +296,7 @@ void SettingsComponent::removeValue(const QString &sectionOrKey)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void SettingsComponent::resetToDefault()
 {
-  foreach(SettingsSection *section, m_sections)
+  for(SettingsSection *section : m_sections)
   {
    section->resetToDefault();
   }
@@ -319,7 +319,7 @@ QVariantList SettingsComponent::settingDescriptions()
   QList<SettingsSection*> sectionList = m_sections.values();
   std::sort(sectionList.begin(), sectionList.end(), SectionOrderIndex());
 
-  foreach(SettingsSection* section, sectionList)
+  for(SettingsSection* section : sectionList)
   {
     if (!section->isHidden())
       desc.push_back(QJsonValue::fromVariant(section->descriptions()));
@@ -347,7 +347,7 @@ bool SettingsComponent::loadDescription()
 
   m_sectionIndex = 0;
 
-  foreach(const QJsonValue& val, doc.array())
+  for(const QJsonValue& val : doc.array())
   {
     if (!val.isObject())
     {
@@ -389,7 +389,7 @@ void SettingsComponent::parseSection(const QJsonObject& sectionObject)
 
   auto values = sectionObject.value("values").toArray();
   int order = 0;
-  foreach(auto val, values)
+  for(auto val : values)
   {
     if (!val.isObject())
       continue;
@@ -404,7 +404,7 @@ void SettingsComponent::parseSection(const QJsonObject& sectionObject)
     {
       defaultval = QVariant();
       // Whichever default matches the current platform first is used.
-      foreach(const auto& v, defaults.toArray())
+      for(const auto& v : defaults.toArray())
       {
         auto vobj = v.toObject();
         int defPlatformMask = platformMaskFromObject(vobj);
@@ -427,7 +427,7 @@ void SettingsComponent::parseSection(const QJsonObject& sectionObject)
     if (valobj.contains("possible_values") && valobj.value("possible_values").isArray())
     {
       auto list = valobj.value("possible_values").toArray();
-      foreach(const auto& v, list)
+      for(const auto& v : list)
       {
         int platform = PLATFORM_ANY;
 
@@ -469,7 +469,7 @@ int SettingsComponent::platformMaskFromObject(const QJsonObject& object)
     // platforms can be both array or a single string
     if (platforms.isArray())
     {
-      foreach(const QJsonValue& pl, platforms.toArray())
+      for(const QJsonValue& pl : platforms.toArray())
       {
         if (!pl.isString())
           continue;
@@ -487,7 +487,7 @@ int SettingsComponent::platformMaskFromObject(const QJsonObject& object)
     QJsonValue val = object.value("platforms_excluded");
     if (val.isArray())
     {
-      foreach(const QJsonValue& pl, val.toArray())
+      for(const QJsonValue& pl : val.toArray())
       {
         if (!pl.isString())
           continue;
@@ -559,7 +559,7 @@ void SettingsComponent::setUserRoleList(const QStringList& userRoles)
 
   values << stable;
 
-  foreach(const QString& role, userRoles)
+  for(const QString& role : userRoles)
   {
     QVariantMap channel;
     int value = 0;

--- a/src/settings/SettingsSection.cpp
+++ b/src/settings/SettingsSection.cpp
@@ -28,13 +28,13 @@ void SettingsSection::setValues(const QVariant& values)
   QVariantMap updatedValues;
 
   // values not included in the map are reset to default
-  foreach (const QString& key, m_values.keys())
+  for(const QString& key : m_values.keys())
   {
     if (!map.contains(key))
       map[key] = m_values[key]->defaultValue();
   }
 
-  foreach (const QString& key, map.keys())
+  for(const QString& key : map.keys())
   {
     if (key.isEmpty())
       continue;
@@ -85,7 +85,7 @@ bool SettingsSection::setValue(const QString& key, const QVariant& value)
 
   QVariantMap values;
   // populate with default values (setValues() resets missing values)
-  foreach (const QString& entry, m_values.keys())
+  for(const QString& entry : m_values.keys())
     values[entry] = m_values[entry]->value();
 
   values[key] = value;
@@ -115,7 +115,7 @@ const QVariantMap SettingsSection::allValues() const
 {
   QVariantMap values;
 
-  foreach (SettingsValue* val, m_values.values())
+  for(SettingsValue* val : m_values.values())
     values[val->key()] = val->value();
 
   return values;
@@ -141,7 +141,7 @@ const QVariantMap SettingsSection::descriptions() const
   std::sort(list.begin(), list.end(), ValueSortOrder());
 
   QVariantList settings;
-  foreach(SettingsValue* value, list)
+  for(SettingsValue* value : list)
   {
     if (!value->isHidden())
       settings.push_back(value->descriptions());
@@ -153,7 +153,7 @@ const QVariantMap SettingsSection::descriptions() const
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void SettingsSection::resetToDefault()
 {
-  foreach (const QString& key, m_values.keys())
+  for(const QString& key : m_values.keys())
     m_values[key]->reset();
 }
 

--- a/src/shared/LocalJsonClient.cpp
+++ b/src/shared/LocalJsonClient.cpp
@@ -29,6 +29,6 @@ bool LocalJsonClient::sendMessage(const QVariantMap& message)
 void LocalJsonClient::readyRead()
 {
   QVariantList list = LocalJsonServer::readFromSocket(this);
-  foreach (const QVariant& msg, list)
+  for(const QVariant& msg : list)
     emit messageReceived(msg.toMap());
 }

--- a/src/shared/LocalJsonServer.cpp
+++ b/src/shared/LocalJsonServer.cpp
@@ -72,7 +72,7 @@ void LocalJsonServer::clientReadyRead()
     return;
 
   QVariantList messages = readFromSocket(socket);
-  foreach (const QVariant& msg, messages)
+  for(const QVariant& msg : messages)
     emit messageReceived(msg.toMap());
 }
 

--- a/src/system/SystemComponent.cpp
+++ b/src/system/SystemComponent.cpp
@@ -220,7 +220,7 @@ QString SystemComponent::debugInformation()
   stream << endl;
 
   stream << "Network Addresses" << endl;
-  foreach (const QString& addr, networkAddresses())
+  for(const QString& addr : networkAddresses())
   {
     stream << "  " << addr << endl;
   }
@@ -240,7 +240,7 @@ int SystemComponent::networkPort() const
 QStringList SystemComponent::networkAddresses() const
 {
   QStringList list;
-  foreach(const QHostAddress& address, QNetworkInterface::allAddresses())
+  for(const QHostAddress& address : QNetworkInterface::allAddresses())
   {
     if (! address.isLoopback() && (address.protocol() == QAbstractSocket::IPv4Protocol ||
                                    address.protocol() == QAbstractSocket::IPv6Protocol))
@@ -258,7 +258,7 @@ QStringList SystemComponent::networkAddresses() const
 void SystemComponent::userInformation(const QVariantMap& userModel)
 {
   QStringList roleList;
-  foreach (const QVariant& role, userModel.value("roles").toList())
+  for(const QVariant& role : userModel.value("roles").toList())
   { 
     roleList << role.toMap().value("id").toString();
   }

--- a/src/system/UpdateManager.cpp
+++ b/src/system/UpdateManager.cpp
@@ -50,7 +50,7 @@ QString UpdateManager::HaveUpdate()
   // sort update directories, sort by the newest directory first, that way
   // we apply the latest update downloaded.
   //
-  foreach (const QString& dir, updateDir.entryList(QDir::NoDotAndDotDot | QDir::Dirs, QDir::Time))
+  for(const QString& dir : updateDir.entryList(QDir::NoDotAndDotDot | QDir::Dirs, QDir::Time))
   {
     // check if this version has been applied
     QString readyFile(GetPath("_readyToApply", dir, false));

--- a/src/tools/helper/CrashUploader.cpp
+++ b/src/tools/helper/CrashUploader.cpp
@@ -26,7 +26,7 @@
 void CrashUploader::deleteOldCrashDumps()
 {
   QDir dir(m_old);
-  foreach (const QString& entry, dir.entryList(QDir::Dirs | QDir::NoDot | QDir::NoDotDot))
+  for(const QString& entry : dir.entryList(QDir::Dirs | QDir::NoDot | QDir::NoDotDot))
   {
     if (entry != Version::GetCanonicalVersionString())
     {
@@ -161,7 +161,7 @@ void CrashUploader::uploadAndDeleteCrashDumps()
   watchCrashDir(false);
 
   // loop over all incoming directories, should give us version numbers in d
-  foreach (const QString& version, dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot))
+  for(const QString& version : dir.entryList(QDir::Dirs | QDir::NoDotAndDotDot))
   {
     QDir versionDir(dir);
     versionDir.cd(version);
@@ -169,7 +169,7 @@ void CrashUploader::uploadAndDeleteCrashDumps()
     QLOG_DEBUG() << "Scanning:" << versionDir.path();
 
     int numUploads = 0;
-    foreach (const QString& entry, versionDir.entryList(filters, QDir::Files))
+    for(const QString& entry : versionDir.entryList(filters, QDir::Files))
     {
       // we only upload 20 crash reports per version
       if (numUploads > 20)

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -95,7 +95,7 @@ KonvergoWindow::~KonvergoWindow()
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 bool KonvergoWindow::fitsInScreens(const QRect& rc)
 {
-  foreach (QScreen *screen, QGuiApplication::screens())
+  for(QScreen *screen : QGuiApplication::screens())
   {
     if (screen->virtualGeometry().contains(rc))
       return true;

--- a/src/utils/CachedRegexMatcher.cpp
+++ b/src/utils/CachedRegexMatcher.cpp
@@ -27,7 +27,7 @@ QVariant CachedRegexMatcher::match(const QString& input)
     return m_matcherCache.value(input);
 
   // otherwise try to iterate our list and find a match
-  foreach(const MatcherValuePair& matcher, m_matcherList)
+  for(const MatcherValuePair& matcher : m_matcherList)
   {
     QRegExp re(matcher.first);
 

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -103,12 +103,12 @@ QString Utils::CurrentUserId()
 QString Utils::PrimaryIPv4Address()
 {
   QList<QNetworkInterface> ifs = QNetworkInterface::allInterfaces();
-  foreach(const QNetworkInterface& iface, ifs)
+  for(const QNetworkInterface& iface : ifs)
   {
     if (iface.isValid() && iface.flags() & QNetworkInterface::IsUp)
     {
       QList<QHostAddress> addresses = iface.allAddresses();
-      foreach(const QHostAddress& addr, addresses)
+      for(const QHostAddress& addr : addresses)
       {
         if (!addr.isLoopback() && !addr.isMulticast() && addr.protocol() == QAbstractSocket::IPv4Protocol)
         {


### PR DESCRIPTION
This is just a cleanup but it makes clang-tidy properly recognise the
loops so it can applies checks to them.