### PR TITLE
Don't assume cflags test for them instead.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,11 +31,12 @@ set(CMAKE_INSTALL_DEFAULT_COMPONENT_NAME Core)
 
 add_definitions(-DQS_LOG_LINE_NUMBERS)
 
+include(utils)
+include(CompilerFlags)
 include(DependencyConfiguration)
 include(QtConfiguration)
 include(VersionConfiguration)
 include(NameConfiguration)
-include(utils)
 include(PlayerConfiguration)
 include(InputConfiguration)
 include(FindBreakpad)
@@ -49,13 +50,6 @@ elseif(WIN32)
 elseif(UNIX AND (NOT APPLE))
   include(LinuxConfiguration)
 endif(APPLE)
-
-if(CMAKE_COMPILER_IS_GNUCC)
-  include(GCCConfiguration)
-endif(CMAKE_COMPILER_IS_GNUCC)
-
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${WARNINGS}")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNINGS}")
 
 if (Qt5_POSITION_INDEPENDENT_CODE)
   SET(CMAKE_POSITION_INDEPENDENT_CODE ON)

--- a/CMakeModules/AppleConfiguration.cmake
+++ b/CMakeModules/AppleConfiguration.cmake
@@ -6,7 +6,7 @@ find_Library(CARBON Carbon)
 find_library(SECURITY Security)
 
 set(OS_LIBS ${FOUNDATION} ${APPKIT} ${IOKIT} ${COCOA} ${SECURITY} ${CARBON} spmediakeytap hidremote)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mmacosx-version-min=10.9 -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mmacosx-version-min=10.9 -fno-omit-frame-pointer")
 set(WARNINGS "-Wall")
 

--- a/CMakeModules/CompilerFlags.cmake
+++ b/CMakeModules/CompilerFlags.cmake
@@ -1,0 +1,15 @@
+# MSVC goes totally bananas if we pass it -Wall
+if(NOT MSVC)
+  enable_if_supported(COMPILER_FLAGS "-Wall")
+endif()
+
+enable_if_supported(COMPILER_FLAGS "-fno-omit-frame-pointer")
+enable_if_supported(COMPILER_FLAGS "-mmacosx-version-min=10.9")
+enable_if_supported(COMPILER_FLAGS "/Oy-")
+
+enable_if_links(LINK_FLAGS "-flto")
+enable_if_links(LINK_FLAGS "-fuse-ld=gold")
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${COMPILER_FLAGS}")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${COMPILER_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${LINK_FLAGS}")

--- a/CMakeModules/GCCConfiguration.cmake
+++ b/CMakeModules/GCCConfiguration.cmake
@@ -1,2 +1,0 @@
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fno-omit-frame-pointer")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-omit-frame-pointer")

--- a/CMakeModules/Win32Configuration.cmake
+++ b/CMakeModules/Win32Configuration.cmake
@@ -2,14 +2,6 @@ set(INSTALL_BIN_DIR .)
 set(INSTALL_RESOURCE_DIR resources)
 set(HAVE_UPDATER 1)
 
-if(${CMAKE_C_COMPILER_ID} STREQUAL MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Oy-")
-endif()
-
-if(${CMAKE_CXX_COMPILER_ID} STREQUAL MSVC)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Oy-")
-endif()
-
 find_library(WINMM winmm)
 find_library(IMMLIB imm32)
 find_library(VERLIB version)

--- a/CMakeModules/utils.cmake
+++ b/CMakeModules/utils.cmake
@@ -68,3 +68,101 @@ function(add_sources)
   # add it to the global list.
   set_property(GLOBAL APPEND PROPERTY SRCS_LIST ${SRCS})
 endfunction(add_sources)
+
+## ---------------------------------------------------------------------
+##
+## Copyright (C) 2012 - 2014 by the deal.II authors
+##
+## This file is part of the deal.II library.
+##
+## The deal.II library is free software; you can use it, redistribute
+## it, and/or modify it under the terms of the GNU Lesser General
+## Public License as published by the Free Software Foundation; either
+## version 2.1 of the License, or (at your option) any later version.
+## The full text of the license can be found in the file LICENSE at
+## the top level of the deal.II distribution.
+##
+## ---------------------------------------------------------------------
+
+#
+# Tests whether the cxx compiler understands a flag.
+# If so, add it to 'variable'.
+#
+# Usage:
+#     ENABLE_IF_SUPPORTED(variable flag)
+#
+
+include(CheckCXXCompilerFlag)
+
+MACRO(ENABLE_IF_SUPPORTED _variable _flag)
+  #
+  # Clang is too conservative when reporting unsupported compiler flags.
+  # Therefore, we promote all warnings for an unsupported compiler flag to
+  # actual errors with the -Werror switch:
+  #
+  IF(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+    SET(_werror_string "-Werror ")
+  ELSE()
+    SET(_werror_string "")
+  ENDIF()
+
+  STRING(STRIP "${_flag}" _flag_stripped)
+  SET(_flag_stripped_orig "${_flag_stripped}")
+
+  #
+  # Gcc does not emit a warning if testing -Wno-... flags which leads to
+  # false positive detection. Unfortunately it later warns that an unknown
+  # warning option is used if another warning is emitted in the same
+  # compilation unit.
+  # Therefore we invert the test for -Wno-... flags:
+  #
+  IF(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+    STRING(REPLACE "-Wno-" "-W" _flag_stripped "${_flag_stripped}")
+  ENDIF()
+
+  IF(NOT "${_flag_stripped}" STREQUAL "")
+    STRING(REGEX REPLACE "^-" "" _flag_name "${_flag_stripped}")
+    STRING(REPLACE "," "" _flag_name "${_flag_name}")
+    STRING(REPLACE "-" "_" _flag_name "${_flag_name}")
+    STRING(REPLACE "+" "_" _flag_name "${_flag_name}")
+    CHECK_CXX_COMPILER_FLAG(
+      "${_werror_string}${_flag_stripped}"
+      HAVE_FLAG_${_flag_name}
+    )
+    IF(HAVE_FLAG_${_flag_name})
+      SET(${_variable} "${${_variable}} ${_flag_stripped_orig}")
+      STRING(STRIP "${${_variable}}" ${_variable})
+    ENDIF()
+  ENDIF()
+ENDMACRO()
+
+#
+# Tests whether it is possible to compile and link a dummy program with a
+# given flag.
+# If so, add it to variable.
+#
+# Usage:
+#     ENABLE_IF_LINKS(variable flag)
+#
+
+MACRO(ENABLE_IF_LINKS _variable _flag)
+  STRING(STRIP "${_flag}" _flag_stripped)
+  IF(NOT "${_flag_stripped}" STREQUAL "")
+    STRING(REGEX REPLACE "^-" "" _flag_name "${_flag_stripped}")
+    STRING(REPLACE "," "" _flag_name "${_flag_name}")
+    STRING(REPLACE "-" "_" _flag_name "${_flag_name}")
+    STRING(REPLACE "+" "_" _flag_name "${_flag_name}")
+    SET(_backup ${CMAKE_REQUIRED_LIBRARIES})
+    LIST(APPEND CMAKE_REQUIRED_LIBRARIES "${_flag_stripped}")
+    CHECK_CXX_COMPILER_FLAG(
+      ""
+      HAVE_FLAG_${_flag_name}
+    )
+    SET(CMAKE_REQUIRED_LIBRARIES ${_backup})
+
+    IF(HAVE_FLAG_${_flag_name})
+      SET(${_variable} "${${_variable}} ${_flag_stripped}")
+      STRING(STRIP "${${_variable}}" ${_variable})
+    ENDIF()
+  ENDIF()
+ENDMACRO()


### PR DESCRIPTION
Instead of maintaining lists per compiler of flags that should
be enabled / disabled we now test for them instead. If they are
able to be used we append them.

Same with linker flags we test for them before assuming they work.