### PR TITLE
Add "Always on top" allowing PMP to float above any other windows

### DIFF
--- a/resources/inputmaps/keyboard.json
+++ b/resources/inputmaps/keyboard.json
@@ -52,14 +52,14 @@
     "Ctrl\\+Q": "host:close",
     "Ctrl\\+Shift\\+R": "host:reload",
     "Ctrl\\+Shift\\+D": "host:toggleDebug",
-    "Ctrl\\+Shift\\+A": "host:alwaysOnTop",
+    "Ctrl\\+Shift\\+A": "host:cycle_setting main.alwaysOnTop",
 
     // emulate some of of PHT's behaviour
     "I": "host:toggleDebug",
     "W": "toggle_watched",
     "\\\\": "host:fullscreen",
     "Z": "host:cycle_setting video.aspect",
-    "T": "host:alwaysOnTop",
+    "T": "host:cycle_setting main.alwaysOnTop",
 
     // media keys from the FLIRC and on Linux keyboards
     "Toggle Media Play\\/Pause": "play_pause",

--- a/resources/inputmaps/keyboard.json
+++ b/resources/inputmaps/keyboard.json
@@ -52,12 +52,14 @@
     "Ctrl\\+Q": "host:close",
     "Ctrl\\+Shift\\+R": "host:reload",
     "Ctrl\\+Shift\\+D": "host:toggleDebug",
+    "Ctrl\\+Shift\\+A": "host:alwaysOnTop",
 
     // emulate some of of PHT's behaviour
     "I": "host:toggleDebug",
     "W": "toggle_watched",
     "\\\\": "host:fullscreen",
     "Z": "host:cycle_setting video.aspect",
+    "T": "host:alwaysOnTop",
 
     // media keys from the FLIRC and on Linux keyboards
     "Toggle Media Play\\/Pause": "play_pause",

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -36,11 +36,7 @@
       },
       {
         "value": "alwaysOnTop",
-        "default": false,
-        "possible_values": [
-          [ false, "Disabled" ],
-          [ true, "Enabled" ]
-        ]
+        "default": false
       },
       {
         "value": "webserverport",

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -35,6 +35,10 @@
         "hidden": true
       },
       {
+        "value": "alwaysOnTop",
+        "default": false
+      },
+      {
         "value": "webserverport",
         "default": 32433,
         "hidden": true

--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -36,7 +36,11 @@
       },
       {
         "value": "alwaysOnTop",
-        "default": false
+        "default": false,
+        "possible_values": [
+          [ false, "Disabled" ],
+          [ true, "Enabled" ]
+        ]
       },
       {
         "value": "webserverport",

--- a/src/settings/SettingsComponent.cpp
+++ b/src/settings/SettingsComponent.cpp
@@ -48,9 +48,15 @@ void SettingsComponent::cycleSetting(const QString& args)
     return;
   }
   QVariantList values = section->possibleValues(valueName);
+  // If no possible values are set, assume that the setting is a simple
+  // checkbox and cycle through the boolean value.
   if (values.size() == 0)
   {
-    QLOG_ERROR() << "Setting" << settingName << "is unknown or is not cycleable.";
+    QVariant currentValue = section->value(valueName);
+    auto nextValue = currentValue.toBool() ? false : true;
+    setValue(sectionID, valueName, nextValue);
+    QLOG_DEBUG() << "Setting" << settingName << "to " << (nextValue ? "Enabled" : "Disabled");
+    emit SystemComponent::Get().settingsMessage(valueName, nextValue ? "Enabled" : "Disabled");
     return;
   }
   QVariant currentValue = section->value(valueName);

--- a/src/settings/SettingsComponent.cpp
+++ b/src/settings/SettingsComponent.cpp
@@ -53,7 +53,7 @@ void SettingsComponent::cycleSetting(const QString& args)
   // Otherwise log an error message, that it's not possible to cycle through the value.
   if (values.size() == 0)
   {
-    if (static_cast<QMetaType::Type>(section->defaultValue(valueName).type()) == QMetaType::Bool)
+    if (section->defaultValue(valueName).type() == QVariant::Bool)
     {
       QVariant currentValue = section->value(valueName);
       auto nextValue = currentValue.toBool() ? false : true;

--- a/src/settings/SettingsComponent.cpp
+++ b/src/settings/SettingsComponent.cpp
@@ -48,16 +48,25 @@ void SettingsComponent::cycleSetting(const QString& args)
     return;
   }
   QVariantList values = section->possibleValues(valueName);
-  // If no possible values are set, assume that the setting is a simple
-  // checkbox and cycle through the boolean value.
+  // If no possible values are defined, check the type of the default value.
+  // In the case it's a boolean simply negate the current value to cycle through.
+  // Otherwise log an error message, that it's not possible to cycle through the value.
   if (values.size() == 0)
   {
-    QVariant currentValue = section->value(valueName);
-    auto nextValue = currentValue.toBool() ? false : true;
-    setValue(sectionID, valueName, nextValue);
-    QLOG_DEBUG() << "Setting" << settingName << "to " << (nextValue ? "Enabled" : "Disabled");
-    emit SystemComponent::Get().settingsMessage(valueName, nextValue ? "Enabled" : "Disabled");
-    return;
+    if (static_cast<QMetaType::Type>(section->defaultValue(valueName).type()) == QMetaType::Bool)
+    {
+      QVariant currentValue = section->value(valueName);
+      auto nextValue = currentValue.toBool() ? false : true;
+      setValue(sectionID, valueName, nextValue);
+      QLOG_DEBUG() << "Setting" << settingName << "to " << (nextValue ? "Enabled" : "Disabled");
+      emit SystemComponent::Get().settingsMessage(valueName, nextValue ? "Enabled" : "Disabled");
+      return;
+    }
+    else
+    {
+      QLOG_ERROR() << "Setting" << settingName << "is unknown or is not cycleable.";
+      return;
+    }
   }
   QVariant currentValue = section->value(valueName);
   int nextValueIndex = 0;

--- a/src/settings/SettingsSection.cpp
+++ b/src/settings/SettingsSection.cpp
@@ -61,6 +61,16 @@ void SettingsSection::setValues(const QVariant& values)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+QVariant SettingsSection::defaultValue(const QString& key)
+{
+  if (m_values.contains(key))
+    return m_values[key]->defaultValue();
+
+  QLOG_WARN() << "Looking for defaultValue:" << key << "in section:" << m_sectionID << "but it can't be found";
+  return QVariant();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 QVariant SettingsSection::value(const QString& key)
 {
   if (m_values.contains(key))

--- a/src/settings/SettingsSection.h
+++ b/src/settings/SettingsSection.h
@@ -27,6 +27,7 @@ public:
   bool isHidden() const;
 
   QVariant value(const QString& key);
+  QVariant defaultValue(const QString& key);
   QString sectionName() const { return m_sectionID; }
 
   const QVariantMap allValues() const;

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -272,7 +272,7 @@ void KonvergoWindow::updateAlwaysOnTopState()
 {
   QLOG_DEBUG() << "Changing always-on-top state";
   Qt::WindowFlags forceOnTopFlags = Qt::WindowStaysOnTopHint;
-#ifdef Q_OS_LINUX
+#ifdef Q_WS_X11
   forceOnTopFlags = forceOnTopFlags | Qt::X11BypassWindowManagerHint;
 #endif
 

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -35,6 +35,7 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) : QQuickWindow(parent), m_debugL
   InputComponent::Get().registerHostCommand("toggleDebug", this, "toggleDebug");
   InputComponent::Get().registerHostCommand("reload", this, "reloadWeb");
   InputComponent::Get().registerHostCommand("fullscreen", this, "toggleFullscreen");
+  InputComponent::Get().registerHostCommand("alwaysOnTop", this, "toggleAlwaysOnTop");
 
 #ifdef TARGET_RPI
   // On RPI, we use dispmanx layering - the video is on a layer below Konvergo,
@@ -70,6 +71,9 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) : QQuickWindow(parent), m_debugL
 #else
   updateFullscreenState(false);
 #endif
+
+  // Check the always on top setting and activate it if necessary.
+  updateAlwaysOnTopState();
 
   emit enableVideoWindowSignal();
 }
@@ -210,6 +214,15 @@ void KonvergoWindow::setFullScreen(bool enable)
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
+void KonvergoWindow::setAlwaysOnTop(bool enable)
+{
+  QLOG_DEBUG() << "setting always on top = " << enable;
+
+  // Update the settings value.
+  SettingsComponent::Get().setValue(SETTINGS_SECTION_MAIN, "alwaysOnTop", enable);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
 void KonvergoWindow::playerWindowVisible(bool visible)
 {
   // adjust webengineview transparecy depending on player visibility
@@ -225,6 +238,11 @@ void KonvergoWindow::updateMainSectionSettings(const QVariantMap& values)
   if (values.find("disablemouse") != values.end())
   {
     SystemComponent::Get().setCursorVisibility(!SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "disablemouse").toBool());
+  }
+
+  if (values.find("alwaysOnTop") != values.end())
+  {
+    updateAlwaysOnTopState();
   }
 
   if (values.find("fullscreen") == values.end())
@@ -250,6 +268,27 @@ void KonvergoWindow::updateFullscreenState(bool saveGeo)
     setVisibility(QWindow::Windowed);
     loadGeometry();
   }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void KonvergoWindow::updateAlwaysOnTopState()
+{
+  QLOG_DEBUG() << "Changing always-on-top state";
+  Qt::WindowFlags forceOnTopFlags = Qt::WindowStaysOnTopHint;
+#ifdef Q_OS_LINUX
+  forceOnTopFlags = forceOnTopFlags | Qt::X11BypassWindowManagerHint;
+#endif
+
+  if(SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "alwaysOnTop").toBool())
+  {
+    setFlags(flags() | forceOnTopFlags);
+  }
+  else
+  {
+    setFlags(flags() & ~forceOnTopFlags);
+  }
+
+  show();
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -240,9 +240,7 @@ void KonvergoWindow::updateMainSectionSettings(const QVariantMap& values)
   }
 
   if (values.find("alwaysOnTop") != values.end())
-  {
     updateAlwaysOnTopState();
-  }
 
   if (values.find("fullscreen") == values.end())
     return;
@@ -278,14 +276,10 @@ void KonvergoWindow::updateAlwaysOnTopState()
   forceOnTopFlags = forceOnTopFlags | Qt::X11BypassWindowManagerHint;
 #endif
 
-  if(SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "alwaysOnTop").toBool())
-  {
+  if (SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "alwaysOnTop").toBool())
     setFlags(flags() | forceOnTopFlags);
-  }
   else
-  {
     setFlags(flags() & ~forceOnTopFlags);
-  }
 
   show();
 }

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -35,7 +35,6 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) : QQuickWindow(parent), m_debugL
   InputComponent::Get().registerHostCommand("toggleDebug", this, "toggleDebug");
   InputComponent::Get().registerHostCommand("reload", this, "reloadWeb");
   InputComponent::Get().registerHostCommand("fullscreen", this, "toggleFullscreen");
-  InputComponent::Get().registerHostCommand("alwaysOnTop", this, "toggleAlwaysOnTop");
 
 #ifdef TARGET_RPI
   // On RPI, we use dispmanx layering - the video is on a layer below Konvergo,

--- a/src/ui/KonvergoWindow.h
+++ b/src/ui/KonvergoWindow.h
@@ -33,6 +33,7 @@ class KonvergoWindow : public QQuickWindow
   Q_PROPERTY(QSize webUISize READ webUISize NOTIFY webScaleChanged)
   Q_PROPERTY(qreal windowScale READ windowScale NOTIFY webScaleChanged)
   Q_PROPERTY(QSize windowMinSize READ windowMinSize NOTIFY webScaleChanged)
+  Q_PROPERTY(bool alwaysOnTop READ isAlwaysOnTop WRITE setAlwaysOnTop)
 
 public:
   static void RegisterClass();
@@ -47,6 +48,17 @@ public:
 
   void setFullScreen(bool enable);
 
+  bool isAlwaysOnTop()
+  {
+    Qt::WindowFlags forceOnTopFlags = Qt::WindowStaysOnTopHint;
+#ifdef Q_OS_LINUX
+    forceOnTopFlags = forceOnTopFlags | Qt::X11BypassWindowManagerHint;
+#endif
+    return (flags() & forceOnTopFlags);
+  }
+
+  void setAlwaysOnTop(bool enable);
+
   Q_SLOT void otherAppFocus()
   {
     setWindowState((Qt::WindowState)((windowState() & ~Qt::WindowMinimized) | Qt::WindowActive));
@@ -58,6 +70,11 @@ public:
   Q_SLOT void toggleFullscreen()
   {
     setFullScreen(!isFullScreen());
+  }
+
+  Q_SLOT void toggleAlwaysOnTop()
+  {
+    setAlwaysOnTop(!isAlwaysOnTop());
   }
 
   Q_SLOT void reloadWeb()
@@ -91,6 +108,7 @@ private slots:
   void onVisibilityChanged(QWindow::Visibility visibility);
   void updateMainSectionSettings(const QVariantMap& values);
   void updateFullscreenState(bool saveGeo = true);
+  void updateAlwaysOnTopState();
   void onScreenCountChanged(int newCount);
   void updateDebugInfo();
   void playerWindowVisible(bool visible);


### PR DESCRIPTION
- Allow the Plex Media Player window to flow above any other windows
- Expose a "alwaysOnTop" control in the settings panel to change the default state
- Allow the always-on-top state to be toggled using the shortcut CMD|Ctrl+Shift+A or T

Plex-CLA-1.0-signed-off-by: Lukas Pitschl <lukas@leftandleaving.com>