### PR TITLE
Allow to enable D-Bus power management using a CMake option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,18 @@ project(PlexMediaPlayer CXX C)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON CACHE BOOL "" FORCE)
 
 option(OPENELEC "Make an OpenELEC build" OFF)
+option(LINUX_DBUS "Enable D-Bus power management" OFF)
 
 if(OPENELEC)
+  set(LINUX_DBUS ON)
   add_definitions(-DKONVERGO_OPENELEC=1)
   Message(STATUS "Making an OpenELEC build")
 endif(OPENELEC)
+
+if(LINUX_DBUS)
+  add_definitions(-DLINUX_DBUS=1)
+  Message(STATUS "Enabling D-Bus power management")
+endif(LINUX_DBUS)
 
 if(BUILD_TARGET STREQUAL "RPI")
   add_definitions(-DTARGET_RPI=1)

--- a/CMakeModules/QtConfiguration.cmake
+++ b/CMakeModules/QtConfiguration.cmake
@@ -38,9 +38,9 @@ if(UNIX AND (NOT APPLE) AND ((NOT BUILD_TARGET STREQUAL "RPI")))
   set(components ${components} X11Extras)
 endif()
 
-if(OPENELEC)
+if(LINUX_DBUS)
   set(components ${components} DBus)
-endif(OPENELEC)
+endif(LINUX_DBUS)
 
 foreach(COMP ${components})
 	set(mod Qt5${COMP})

--- a/src/power/CMakeLists.txt
+++ b/src/power/CMakeLists.txt
@@ -8,9 +8,9 @@ if(USE_X11POWER)
   add_sources(PowerComponentX11.cpp PowerComponentX11.h)
 endif(USE_X11POWER)
 
-if(OPENELEC)
-  add_sources(PowerComponentOE.cpp PowerComponentOE.h)
-endif(OPENELEC)
+if(LINUX_DBUS)
+  add_sources(PowerComponentDBus.cpp PowerComponentDBus.h)
+endif(LINUX_DBUS)
 
 if(WIN32)
   add_sources(PowerComponentWin.cpp PowerComponentWin.h)

--- a/src/power/PowerComponent.cpp
+++ b/src/power/PowerComponent.cpp
@@ -9,8 +9,8 @@
 
 #ifdef Q_OS_MAC
 #include "PowerComponentMac.h"
-#elif KONVERGO_OPENELEC
-#include "PowerComponentOE.h"
+#elif LINUX_DBUS
+#include "PowerComponentDBus.h"
 #elif USE_X11POWER
 #include "PowerComponentX11.h"
 #elif defined(Q_OS_WIN32)
@@ -23,8 +23,8 @@ PowerComponent& PowerComponent::Get()
 #ifdef Q_OS_MAC
   static PowerComponentMac instance;
   return instance;
-#elif KONVERGO_OPENELEC
-  static PowerComponentOE instance;
+#elif LINUX_DBUS
+  static PowerComponentDBus instance;
   return instance;
 #elif USE_X11POWER
   static PowerComponentX11 instance;

--- a/src/power/PowerComponentDBus.cpp
+++ b/src/power/PowerComponentDBus.cpp
@@ -2,14 +2,14 @@
 #include <QtDBus/QDBusInterface>
 #include <QtDBus/QDBusReply>
 
-#include "PowerComponentOE.h"
+#include "PowerComponentDBus.h"
 
 #define DBUS_SERVICE_NAME "org.freedesktop.login1"
 #define DBUS_SERVICE_PATH "/org/freedesktop/login1"
 #define DBUS_INTERFACE "org.freedesktop.login1.Manager"
 
 /////////////////////////////////////////////////////////////////////////////////////////
-bool PowerComponentOE::callPowerMethod(QString method)
+bool PowerComponentDBus::callPowerMethod(QString method)
 {
   if (QDBusConnection::systemBus().isConnected())
   {
@@ -45,7 +45,7 @@ bool PowerComponentOE::callPowerMethod(QString method)
 }
 
 /////////////////////////////////////////////////////////////////////////////////////////
-bool PowerComponentOE::isPowerMethodAvailable(QString method)
+bool PowerComponentDBus::isPowerMethodAvailable(QString method)
 {
   if (QDBusConnection::systemBus().isConnected())
   {

--- a/src/power/PowerComponentDBus.h
+++ b/src/power/PowerComponentDBus.h
@@ -1,13 +1,13 @@
-#ifndef POWERCOMPONENTOE_H
-#define POWERCOMPONENTOE_H
+#ifndef POWERCOMPONENTDBUS_H
+#define POWERCOMPONENTDBUS_H
 
 #include "PowerComponent.h"
 
-class PowerComponentOE : public PowerComponent
+class PowerComponentDBus : public PowerComponent
 {
   public:
-    PowerComponentOE() : PowerComponent(0) {};
-    ~PowerComponentOE() {};
+    PowerComponentDBus() : PowerComponent(0) {};
+    ~PowerComponentDBus() {};
 
   public Q_SLOTS:
 
@@ -32,4 +32,4 @@ class PowerComponentOE : public PowerComponent
     bool isPowerMethodAvailable(QString method);
 };
 
-#endif // POWERCOMPONENTOE_H
+#endif // POWERCOMPONENTDBUS_H


### PR DESCRIPTION
At this time, only OpenELEC builds can use D-Bus for power-related operations (Shutdown/Reboot/Suspend).

This pull request allow to enable D-Bus on any Linux distribution using a new `-DLINUX_DBUS` option at compile time.

For more clarity, I've renamed the `PowerComponentOE`class to `PowerComponentDBus`. The `LINUX_DBUS` option is always enabled for OpenELEC builds.