### PR TITLE
Fix CGDisplayMode comparison on macOS

### DIFF
--- a/src/display/osx/DisplayManagerOSX.cpp
+++ b/src/display/osx/DisplayManagerOSX.cpp
@@ -120,10 +120,14 @@ int DisplayManagerOSX::getCurrentDisplayMode(int display)
     return -1;
   
   CGDisplayModeRef currentMode = CGDisplayCopyDisplayMode(m_osxDisplays[display]);
+  uint32_t currentIOKitID = CGDisplayModeGetIODisplayModeID(currentMode);
 
   for (int mode = 0; mode < CFArrayGetCount(m_osxDisplayModes[display]); mode++)
   {
-    if (currentMode == (CGDisplayModeRef)CFArrayGetValueAtIndex(m_osxDisplayModes[display], mode))
+    CGDisplayModeRef checkMode = (CGDisplayModeRef)CFArrayGetValueAtIndex(m_osxDisplayModes[display], mode);
+    uint32_t checkIOKitID = CGDisplayModeGetIODisplayModeID(checkMode);
+
+    if (currentIOKitID == checkIOKitID)
     {
       CFRelease(currentMode);
       return mode;


### PR DESCRIPTION
This fixes an issue I encountered on macOS where the current display mode could not be determined, causing the Display FPS to be set to 0, and preventing Display Sync (and mpv’s interpolation feature) from working correctly.

Here’s the associated error I was seeing in my logs:
`DisplayManager : unable to retrieve current video mode`

This change attempts to compare CGDisplayModes using the IOKit ID, rather than comparing the CGDisplayMode references.

I tested this fix by switching between displays and switching resolutions; the current mode identified on the debug screen appears to update correctly, mpv’s interpolation appears to work correctly, and the log error is no longer present. My system is running 10.12.3 on 2016 MBP 13”.

This is my first time working with macOS APIs, so apologies if anything is isn’t quite right.