### PR TITLE
Fully encode URLs when loading files

### DIFF
--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -306,7 +306,7 @@ void PlayerComponent::queueMedia(const QString& url, const QVariantMap& options,
     qurl.setHost(ConvertPlexDirectURL(host));
 
   QVariantList command;
-  command << "loadfile" << qurl.toString();
+  command << "loadfile" << qurl.toString(QUrl::FullyEncoded);
   command << "append-play"; // if nothing is playing, play it now, otherwise just enqueue it
 
   QVariantMap extraArgs;


### PR DESCRIPTION
This properly encodes the URL passed from the web client, including spaces in the `X-Plex-Product` query parameter. The logs now show `X-Plex-Product=Plex%20Media%20Player` instead of `X-Plex-Product=Plex Media Player`.

QT's doc links:
http://doc.qt.io/qt-5/qurl.html#toString
http://doc.qt.io/qt-5/qurl.html#ComponentFormattingOption-enum