### PR TITLE
Avoid X11 / QT symbols clashing

### DIFF
--- a/src/display/x11/DisplayManagerX11.h
+++ b/src/display/x11/DisplayManagerX11.h
@@ -9,6 +9,13 @@
 #undef CursorShape
 #undef Bool
 #undef Status
+#undef None
+#undef KeyPress
+#undef KeyRelease
+#undef FocusIn
+#undef FocusOut
+#undef FontChange
+#undef Expose
 
 #include "display/DisplayManager.h"
 


### PR DESCRIPTION
The following X11 symbols:

None
KeyPress
KeyRelease
FocusIn
FocusOut
FontChange
Expose

must be #undef before to compile QT-related code.
This helped me to compile under Gentoo Linux

Ciao

luigi
