### PR TITLE
player: add playback speed control interface

### DIFF
--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -1524,3 +1524,17 @@ QString PlayerComponent::videoInformation() const
   return infoStr;
 }
 
+/////////////////////////////////////////////////////////////////////////////////////////
+void PlayerComponent::setPlaybackSpeed(double speed)
+{
+  mpv::qt::set_property(m_mpv, "speed", speed);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+double PlayerComponent::playbackSpeed()
+{
+  QVariant speed = mpv::qt::get_property(m_mpv, "speed");
+  if (speed.isValid())
+    return speed.toDouble();
+  return 0;
+}

--- a/src/player/PlayerComponent.h
+++ b/src/player/PlayerComponent.h
@@ -119,6 +119,10 @@ public:
 
   QRect videoRectangle() { return m_videoRectangle; }
 
+  // Set the playback speed (1.0 = normal speed, 2.0 = 2x)
+  Q_INVOKABLE void setPlaybackSpeed(double speed);
+  Q_INVOKABLE virtual double playbackSpeed();
+
   const mpv::qt::Handle getMpvHandle() const { return m_mpv; }
 
   virtual void setWindow(QQuickWindow* window);


### PR DESCRIPTION
This commit adds player playback speed control interface for web-client.

with `setPlaybackSpeed(double)` and `double playbackSpeed()`

Speed is defined as a speed factor ie 1.0 = normal playback speed, 2.0 is double speed etc …