### PR TITLE
powercomponent: only report relaunch capability on embedded, fixes #354

### DIFF
--- a/src/power/PowerComponent.h
+++ b/src/power/PowerComponent.h
@@ -34,9 +34,16 @@ public Q_SLOTS:
   bool canPowerOff() { return checkCap(CAP_POWER_OFF); }
   bool canReboot() { return checkCap(CAP_REBOOT); }
   bool canSuspend() { return checkCap(CAP_SUSPEND); }
-  bool canRelaunch() { return checkCap(CAP_RELAUNCH); }
+  bool canRelaunch()
+  {
+#if OPENELEC
+      return true;
+#else
+      return false;
+#endif
+  }
 
-  virtual int getPowerCapabilities() { return CAP_RELAUNCH; }
+  virtual int getPowerCapabilities() { return 0; }
 
   virtual bool PowerOff() { return false; }
   virtual bool Reboot() { return false; }


### PR DESCRIPTION
Reporting the relaunch capability gets web to display a relaunch menu entry.

That menu entry is only valid on Embedded where systemd will keep on relaunching upon PMP exit.
On linux builds, this will get reported as supported, and will therefore show the relaunch menu item.
When users click on it, it will simply exit, without relaunching.

We just make it valid for embedded with that patch.

cc @sixones