### PR TITLE
icon: Do not enforce icon on startup, fixes #622

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -165,7 +165,11 @@ int main(int argc, char *argv[])
       qputenv("QT_SCALE_FACTOR", scale.toUtf8());
 
     QApplication app(newArgc, newArgv);
+#if Q_OS_WIN
+    // Setting the icon on Windows is necessary but will break user
+    // ability to change icon on OSX
     app.setWindowIcon(QIcon(":/images/icon.png"));
+#endif
 
 #if defined(Q_OS_MAC) && defined(NDEBUG)
     PFMoveToApplicationsFolderIfNecessary();


### PR DESCRIPTION
We enforce the icon onstartup and this has been reported as an issue for people willing to change the application Icon.

it seems that the application icon is anyways handled with the svg icon we have which is bundled into the app.