### PR TITLE
macOS: let Cocoa handle window restoration

### DIFF
--- a/src/display/osx/DisplayManagerOSX.cpp
+++ b/src/display/osx/DisplayManagerOSX.cpp
@@ -51,7 +51,7 @@ bool DisplayManagerOSX::initialize()
     for (int modeid = 0; modeid < numModes; modeid++)
     {
       totalModes++;
-      
+
       // add the videomode to the display
       DMVideoModePtr mode = DMVideoModePtr(new DMVideoMode);
       mode->m_id = modeid;
@@ -94,7 +94,7 @@ bool DisplayManagerOSX::setDisplayMode(int display, int mode)
 {
   if (!isValidDisplayMode(display, mode) || !m_osxDisplayModes[display])
     return false;
-  
+
   CGDisplayModeRef displayMode =
   (CGDisplayModeRef)CFArrayGetValueAtIndex(m_osxDisplayModes[display], mode);
 
@@ -105,11 +105,6 @@ bool DisplayManagerOSX::setDisplayMode(int display, int mode)
     return false;
   }
 
-  // HACK : on OSX, switching display mode can leave dock in a state where mouse cursor
-  // will not hide on top of hidden dock, so we reset it state to fix this
-  OSXUtils::SetPresentationOptions(OSXUtils::GetPresentationOptionsForFullscreen(false));
-  OSXUtils::SetPresentationOptions(OSXUtils::GetPresentationOptionsForFullscreen(true));
-
   return true;
 }
 
@@ -118,7 +113,7 @@ int DisplayManagerOSX::getCurrentDisplayMode(int display)
 {
   if (!isValidDisplay(display) || !m_osxDisplayModes[display])
     return -1;
-  
+
   CGDisplayModeRef currentMode = CGDisplayCopyDisplayMode(m_osxDisplays[display]);
   uint32_t currentIOKitID = CGDisplayModeGetIODisplayModeID(currentMode);
 

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -38,8 +38,7 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) :
   QQuickWindow(parent),
   m_debugLayer(false),
   m_ignoreFullscreenSettingsChange(0),
-  m_showedUpdateDialog(false),
-  m_osxPresentationOptions(0)
+  m_showedUpdateDialog(false)
 {
   // NSWindowCollectionBehaviorFullScreenPrimary is only set on OSX if Qt::WindowFullscreenButtonHint is set on the window.
   setFlags(flags() | Qt::WindowFullscreenButtonHint);
@@ -68,7 +67,15 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) :
   setColor(QColor("#000000"));
 #endif
 
-  QRect loadedGeo = loadGeometry();
+#ifdef Q_OS_MAC
+  OSXUtils::SetWindowRestoration(this);
+  // If we're on macOS, just load the default geometry; Cocoa will restore our size,
+  // position, and fullscreen status from our last session (if applicable).
+  //
+  QRect loadedGeo = getDefaultGeometry();
+  setGeometry(loadedGeo);
+  setVisibility(QWindow::Windowed);
+#endif
 
   connect(SettingsComponent::Get().getSection(SETTINGS_SECTION_MAIN), &SettingsSection::valuesUpdated,
           this, &KonvergoWindow::updateMainSectionSettings);
@@ -101,13 +108,9 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) :
   connect(&UpdaterComponent::Get(), &UpdaterComponent::downloadComplete,
           this, &KonvergoWindow::showUpdateDialog);
 
-#ifdef Q_OS_MAC
-  m_osxPresentationOptions = 0;
-#endif
-
 #ifdef KONVERGO_OPENELEC
   setVisibility(QWindow::FullScreen);
-#else
+#elsif !defined(Q_OS_MAC)
   updateWindowState(false);
 #endif
 
@@ -169,8 +172,10 @@ void KonvergoWindow::showUpdateDialog()
 /////////////////////////////////////////////////////////////////////////////////////////
 void KonvergoWindow::closingWindow()
 {
+#ifndef Q_OS_MAC
   if (!SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "fullscreen").toBool())
     saveGeometry();
+#endif
 
   qApp->quit();
 }
@@ -192,6 +197,21 @@ bool KonvergoWindow::fitsInScreens(const QRect& rc)
   return false;
 }
 
+///////////////////////////////////////////////////////////////////////////////////////////////////
+QRect KonvergoWindow::getDefaultGeometry()
+{
+  // Default to 720p in the middle of the screen
+  if (QScreen *curScreen = screen())
+  {
+    return QRect((curScreen->geometry().width() - WEBUI_SIZE.width()) / 2,
+                 (curScreen->geometry().height() - WEBUI_SIZE.height()) / 2,
+                 WEBUI_SIZE.width(), WEBUI_SIZE.height());
+  }
+
+  return QRect(0, 0, WEBUI_SIZE.width(), WEBUI_SIZE.height());
+}
+
+#ifndef Q_OS_MAC
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void KonvergoWindow::saveGeometry()
 {
@@ -257,15 +277,7 @@ QRect KonvergoWindow::loadGeometry()
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 QRect KonvergoWindow::loadGeometryRect()
 {
-  // if we dont have anything, default to 720p in the middle of the screen
-  QScreen *curScreen = screen();
-  QRect defaultRect = QRect(0, 0, WEBUI_SIZE.width(), WEBUI_SIZE.height());
-  if (curScreen)
-  {
-    defaultRect = QRect((curScreen->geometry().width() - WEBUI_SIZE.width()) / 2,
-                        (curScreen->geometry().height() - WEBUI_SIZE.height()) / 2,
-                        WEBUI_SIZE.width(), WEBUI_SIZE.height());
-  }
+  QRect defaultRect = getDefaultGeometry();
 
   QVariantMap map = SettingsComponent::Get().value(SETTINGS_SECTION_STATE, "geometry").toMap();
   if (map.isEmpty())
@@ -298,6 +310,7 @@ QRect KonvergoWindow::loadGeometryRect()
 
   return rc;
 }
+#endif
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void KonvergoWindow::enableVideoWindow()
@@ -453,10 +466,12 @@ void KonvergoWindow::updateWindowState(bool saveGeo)
 {
   if (SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "fullscreen").toBool() || SystemComponent::Get().isOpenELEC() || SettingsComponent::Get().value(SETTINGS_SECTION_MAIN, "forceAlwaysFS").toBool())
   {
+#ifndef Q_OS_MAC
     // if we were go from windowed to fullscreen
     // we want to store our current windowed position
     if (!isFullScreen() && saveGeo)
       saveGeometry();
+#endif
 
     setVisibility(QWindow::FullScreen);
 
@@ -470,7 +485,9 @@ void KonvergoWindow::updateWindowState(bool saveGeo)
   else
   {
     setVisibility(QWindow::Windowed);
+#ifndef Q_OS_MAC
     loadGeometry();
+#endif
 
     Qt::WindowFlags forceOnTopFlags = Qt::WindowStaysOnTopHint;
 #ifdef Q_WS_X11
@@ -544,19 +561,6 @@ void KonvergoWindow::onVisibilityChanged(QWindow::Visibility visibility)
 
     SystemComponent::Get().setCursorVisibility(false);
   }
-
-#ifdef Q_OS_MAC
-  if (visibility == QWindow::Windowed)
-  {
-    QTimer::singleShot(1 * 1000, [this] { OSXUtils::SetPresentationOptions(m_osxPresentationOptions); });
-  }
-  else if (visibility == QWindow::FullScreen)
-  {
-    QTimer::singleShot(1 * 1000, [this] {
-      OSXUtils::SetPresentationOptions(m_osxPresentationOptions | OSXUtils::GetPresentationOptionsForFullscreen(!m_webDesktopMode));
-    });
-  }
-#endif
 
   InputComponent::Get().cancelAutoRepeat();
 }

--- a/src/ui/KonvergoWindow.h
+++ b/src/ui/KonvergoWindow.h
@@ -116,9 +116,12 @@ private slots:
   void updateCurrentScreen();
 
 private:
+  QRect getDefaultGeometry();
+#ifndef Q_OS_MAC
   void saveGeometry();
   QRect loadGeometry();
   QRect loadGeometryRect();
+#endif
   bool fitsInScreens(const QRect& rc);
   QScreen* loadLastScreen();
   void updateScreens();
@@ -132,7 +135,6 @@ private:
   bool m_webDesktopMode;
   bool m_showedUpdateDialog;
 
-  unsigned long m_osxPresentationOptions;
   QString m_currentScreenName;
 
   void setWebMode(bool newDesktopMode, bool fullscreen);

--- a/src/utils/osx/OSXUtils.h
+++ b/src/utils/osx/OSXUtils.h
@@ -4,15 +4,16 @@
 #include <QString>
 #include <ApplicationServices/ApplicationServices.h>
 
+class KonvergoWindow;
+
 namespace OSXUtils
 {
   QString ComputerName();
   OSStatus SendAppleEventToSystemProcess(AEEventID eventToSendID);
 
-  void SetPresentationOptions(unsigned long flags);
-  unsigned long GetPresentationOptions();
-  unsigned long GetPresentationOptionsForFullscreen(bool hideMenuAndDock);
   void SetCursorVisible(bool visible);
+
+  void SetWindowRestoration(KonvergoWindow* window);
 };
 
 #endif /* OSXUTILS_H */

--- a/src/utils/osx/OSXUtils.mm
+++ b/src/utils/osx/OSXUtils.mm
@@ -1,39 +1,8 @@
 #include "OSXUtils.h"
 #include "QsLog.h"
+#include "ui/KonvergoWindow.h"
+#include "core/Globals.h"
 #import <Cocoa/Cocoa.h>
-
-/////////////////////////////////////////////////////////////////////////////////////////
-unsigned long OSXUtils::GetPresentationOptionsForFullscreen(bool hideMenuAndDock)
-{
-  unsigned long flags = 0;
-  if (hideMenuAndDock)
-  {
-    flags = flags & ~(NSApplicationPresentationAutoHideDock | NSApplicationPresentationAutoHideMenuBar);
-    flags |= NSApplicationPresentationHideDock | NSApplicationPresentationHideMenuBar;
-  }
-  else
-  {
-    flags = flags & ~(NSApplicationPresentationHideDock | NSApplicationPresentationHideMenuBar);
-    flags |= NSApplicationPresentationAutoHideDock | NSApplicationPresentationAutoHideMenuBar;
-  }
-
-  return flags;
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-void OSXUtils::SetPresentationOptions(unsigned long flags)
-{
-  QLOG_DEBUG() << "Setting presentationOptions =" << flags;
-  [[NSApplication sharedApplication] setPresentationOptions:flags];
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-unsigned long OSXUtils::GetPresentationOptions()
-{
-  unsigned long options = [[NSApplication sharedApplication] presentationOptions];
-  QLOG_DEBUG() << "Getting presentationOptions =" << options;
-  return options;
-}
 
 /////////////////////////////////////////////////////////////////////////////////////////
 QString OSXUtils::ComputerName()
@@ -80,4 +49,31 @@ void OSXUtils::SetCursorVisible(bool visible)
     [NSCursor unhide];
   else
     [NSCursor hide];
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+@interface PMPWindowRestoration : NSObject
++ (void)restoreWindowWithIdentifier:(NSString *)identifier
+                              state:(NSCoder *)state
+                  completionHandler:(void (^)(NSWindow *, NSError *))completionHandler;
+@end
+
+@implementation PMPWindowRestoration
+
++ (void)restoreWindowWithIdentifier:(NSString *)identifier state:(NSCoder *)state completionHandler:(void (^)(NSWindow *, NSError *))completionHandler
+{
+  KonvergoWindow* window = Globals::MainWindow();
+  NSView* view = (NSView*)window->winId();
+  completionHandler(view.window, nil);
+}
+
+@end
+
+/////////////////////////////////////////////////////////////////////////////////////////
+void OSXUtils::SetWindowRestoration(KonvergoWindow* window)
+{
+  NSView* view = (NSView*)window->winId();
+  NSWindow* win = view.window;
+  win.restorable = YES;
+  win.restorationClass = [PMPWindowRestoration class];
 }


### PR DESCRIPTION
This fixes a number of quirks around startup where we'd fail to restore our previous geometry, particularly if entering fullscreen. Cocoa handles this much more reliably internally.