### PR TITLE
PlayerComponent: force seek support in all media

### DIFF
--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -124,6 +124,8 @@ bool PlayerComponent::componentInitialize()
 
   mpv::qt::set_property(m_mpv, "tls-verify", "yes");
 
+  mpv::qt::set_property(m_mpv, "force-seekable", "yes");
+
 #if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
   QList<QByteArray> list;
   list << "/etc/ssl/certs/ca-certificates.crt"


### PR DESCRIPTION
This allows Web to do some smarter things around MKV seeking.