### PR TITLE
Add back key to blacklisted media keys, fixes #696

### DIFF
--- a/src/ui/EventFilter.cpp
+++ b/src/ui/EventFilter.cpp
@@ -17,7 +17,8 @@ static QStringList desktopWhiteListedKeys = { "Media Play",
                                               "Media Next",
                                               "Media Previous",
                                               "Media Rewind",
-                                              "Media FastForward" };
+                                              "Media FastForward",
+                                              "Back"};
 // These just happen to be mostly the same.
 static QStringList win32AppcommandBlackListedKeys = desktopWhiteListedKeys;
 


### PR DESCRIPTION
When using MCE remote, the "back" key will fire an media Back Key as well in the same way media Keys do.
This patch allows to filter the second event which has a native virtual key set to 166.

Tested with public testing build (see associated GHI).