### PR TITLE
Use native full screen in macOS, fixes #688 and #695

### DIFF
--- a/src/ui/KonvergoWindow.h
+++ b/src/ui/KonvergoWindow.h
@@ -122,8 +122,9 @@ private:
   bool fitsInScreens(const QRect& rc);
   QScreen* loadLastScreen();
   void updateScreens();
-  void updateForcedScreen();
+  bool updateForcedScreen();
   QScreen* findCurrentScreen();
+  void setWindowFullScreen(bool fullScreen);
 
   bool m_debugLayer;
   QTimer* m_infoTimer;

--- a/src/utils/osx/OSXUtils.h
+++ b/src/utils/osx/OSXUtils.h
@@ -2,6 +2,8 @@
 #define OSXUTILS_H
 
 #include <QString>
+#include <QWindow>
+#include <QRect>
 #include <ApplicationServices/ApplicationServices.h>
 
 namespace OSXUtils
@@ -13,6 +15,9 @@ namespace OSXUtils
   unsigned long GetPresentationOptions();
   unsigned long GetPresentationOptionsForFullscreen(bool hideMenuAndDock);
   void SetCursorVisible(bool visible);
+  bool isWindowFullScreen(QWindow *window);
+  void SetWindowFullScreen(QWindow *window, bool fullScreen);
+  void SetWindowFullScreenOnSpecificScreen(QWindow *qtWindow, QRect screenRect);
 };
 
 #endif /* OSXUTILS_H */


### PR DESCRIPTION
Qt's method for making a window full screen (i.e. `QWindow::setVisible(QWindow::FullScreen)`) is broken in macOS, in that it does not use macOS's native full screen functionality. This PR works around this by using Cocoa to make a window full screen natively when compiling for macOS. Fixes #688 and #695.