### PR TITLE
installer: do not remove shortcuts when updating, fixes #425

### DIFF
--- a/bundle/win/PMP.wxs
+++ b/bundle/win/PMP.wxs
@@ -69,6 +69,7 @@
       <!-- Prevent downgrades from newer versions -->
       <Custom Action="PreventDowngrades" After="FindRelatedProducts">NEWERPRODUCTFOUND</Custom>
       <!-- Uninstall older versions before installing ourselves -->
+      <RemoveShortcuts>Installed AND NOT UPGRADINGPRODUCTCODE</RemoveShortcuts>
       <RemoveExistingProducts After="InstallInitialize">PREVIOUSVERSIONINSTALLED</RemoveExistingProducts>
       <Custom Action="LaunchPMP" After="InstallFinalize"><![CDATA[AUTOLAUNCH = 1]]></Custom>
       <Custom Action="WixCloseApplications" After="InstallInitialize" />


### PR DESCRIPTION
Current installer will remove completely the previous installed version before installing the update
This results in breaking the pinned taskbar shortcuts at every update which is irritating for users.

That patch will skip the shortcuts removal. This will also skip the shortcut removal when completely uninstalling the app, but windows will propose to remove it next time you click it and that the app was uninstalled.

So this is improving current situation even if not perfect.

This was tested and confirmed to fix the issue by otto.
