### PR TITLE
Update to Qt 5.9.5 

### DIFF
--- a/CMakeModules/DependencyConfiguration.cmake
+++ b/CMakeModules/DependencyConfiguration.cmake
@@ -37,7 +37,7 @@ if(WIN32)
     ARCHSTR windows-x86_x64
   )
 
-  option(ENABLE_ANGLE_DEP "Enable downloading and deployment of separate ANGLE deps" ON)
+  option(ENABLE_ANGLE_DEP "Enable downloading and deployment of separate ANGLE deps" OFF)
   if(ENABLE_ANGLE_DEP)
     message(STATUS "Downloading separate ANGLE deps...")
     foreach(angle_file libEGL.dll libGLESv2.dll d3dcompiler_47.dll)

--- a/CMakeModules/QtConfiguration.cmake
+++ b/CMakeModules/QtConfiguration.cmake
@@ -10,7 +10,7 @@ if(NOT IS_DIRECTORY ${QTROOT})
 		"plexmediaplayer-qt"
 		DIRECTORY dir
 		DEPHASH_VAR QT_DEPS_HASH
-    BUILD_NUMBER 165
+    BUILD_NUMBER 206
     ARTIFACTNAME konvergo-qt
     DYLIB_SCRIPT_PATH ${PROJECT_SOURCE_DIR}/scripts/fix-install-names.py
 	)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 You need:
 
-* Qt 5.7.1
+* Qt 5.9.5
 * cmake 3.1 or newer
 * ninja is recommended for building
 * FFmpeg 3.x and mpv from github
@@ -50,7 +50,7 @@ Systems not based on Debian/Ubuntu will have similar packages, but you'll need t
 
 ### Downloading and installing Qt
 
-If your distro provides Qt 5.7.1 or later packages, try to use them. Otherwise, find a Qt download at qt.io.
+If your distro provides Qt 5.9.5 or later packages, try to use them. Otherwise, find a Qt download at qt.io.
 
 On Windows and OSX, you can omit the ``-DQTROOT`` argument to use the Qt built by Plex. (Untested whether this works reliably.)
 

--- a/qt-patches/qt5-5.9.5.patch
+++ b/qt-patches/qt5-5.9.5.patch
@@ -1,0 +1,319 @@
+--- qtwebengine/src/core/web_engine_context.cpp
++++ qtwebengine/src/core/web_engine_context.cpp
+@@ -376,6 +376,13 @@
+         parsedCommandLine->AppendSwitchASCII(switches::kProfilerTiming, switches::kProfilerTimingDisabledValue);
+     }
+ 
++    parsedCommandLine->AppendSwitch(switches::kEnableViewport);
++#if defined(Q_OS_WIN)
++    parsedCommandLine->AppendSwitch(switches::kDisableGpu);
++#endif
++    parsedCommandLine->AppendSwitch(switches::kDisableWebSecurity);
++
++
+     GLContextHelper::initialize();
+ 
+     const char *glType = 0;
+--- qtbase/src/plugins/platforms/cocoa/qnsview.mm
++++ qtbase/src/plugins/platforms/cocoa/qnsview.mm
+@@ -584,7 +584,7 @@
+         return NO;
+     if ([self isTransparentForUserInput])
+         return NO;
+-    return YES;
++    return NO;
+ }
+
+ - (NSView *)hitTest:(NSPoint)aPoint
+--- qtbase/src/gui/kernel/qsurfaceformat.cpp
++++ qtbase/src/gui/kernel/qsurfaceformat.cpp
+@@ -110,6 +110,7 @@
+     int major;
+     int minor;
+     int swapInterval;
++    QSurfaceFormat::OrientationFlags orientationFlags;
+ };
+
+ /*!
+@@ -736,6 +737,16 @@
+     return d->swapInterval;
+ }
+
++QSurfaceFormat::OrientationFlags QSurfaceFormat::orientationFlags() const
++{
++    return d->orientationFlags;
++}
++
++void QSurfaceFormat::setOrientationFlags(QSurfaceFormat::OrientationFlags orientationFlags)
++{
++    d->orientationFlags = orientationFlags;
++}
++
+ Q_GLOBAL_STATIC(QSurfaceFormat, qt_default_surface_format)
+
+ /*!
+--- qtbase/src/gui/kernel/qsurfaceformat.h
++++ qtbase/src/gui/kernel/qsurfaceformat.h
+@@ -57,7 +57,8 @@
+         StereoBuffers            = 0x0001,
+         DebugContext             = 0x0002,
+         DeprecatedFunctions      = 0x0004,
+-        ResetNotification        = 0x0008
++        ResetNotification        = 0x0008,
++        UseOptimalOrientation    = 0x0010
+     };
+     Q_ENUM(FormatOption)
+     Q_DECLARE_FLAGS(FormatOptions, FormatOption)
+@@ -85,6 +86,11 @@
+     };
+     Q_ENUM(OpenGLContextProfile)
+
++    enum OrientationFlag {
++        MirrorVertically = 0x0001,
++    };
++    Q_DECLARE_FLAGS(OrientationFlags, OrientationFlag)
++
+     QSurfaceFormat();
+     /*implicit*/ QSurfaceFormat(FormatOptions options);
+     QSurfaceFormat(const QSurfaceFormat &other);
+@@ -145,6 +151,9 @@
+     int swapInterval() const;
+     void setSwapInterval(int interval);
+
++    QSurfaceFormat::OrientationFlags orientationFlags() const;
++    void setOrientationFlags(QSurfaceFormat::OrientationFlags orientationFlags);
++
+     static void setDefaultFormat(const QSurfaceFormat &format);
+     static QSurfaceFormat defaultFormat();
+
+--- qtbase/src/plugins/platforms/windows/qwindowseglcontext.cpp
++++ qtbase/src/plugins/platforms/windows/qwindowseglcontext.cpp
+@@ -297,11 +297,25 @@
+     return new QWindowsEGLContext(this, context->format(), context->shareHandle());
+ }
+
+-void *QWindowsEGLStaticContext::createWindowSurface(void *nativeWindow, void *nativeConfig, int *err)
++void *QWindowsEGLStaticContext::createWindowSurface(void *nativeWindow, void *nativeConfig, const QSurfaceFormat format, int *err)
+ {
+     *err = 0;
++
++    std::vector<EGLint> attrib_list;
++#ifdef EGL_ANGLE_surface_orientation
++    if (format.testOption(QSurfaceFormat::UseOptimalOrientation)) {
++        EGLint surfaceOrientation = 0;
++        libEGL.eglGetConfigAttrib(m_display, nativeConfig, EGL_OPTIMAL_SURFACE_ORIENTATION_ANGLE, &surfaceOrientation);
++        if (surfaceOrientation & EGL_SURFACE_ORIENTATION_INVERT_Y_ANGLE) {
++            attrib_list.push_back(EGL_SURFACE_ORIENTATION_ANGLE);
++            attrib_list.push_back(EGL_SURFACE_ORIENTATION_INVERT_Y_ANGLE);
++        }
++    }
++#endif
++    attrib_list.push_back(EGL_NONE);
+     EGLSurface surface = libEGL.eglCreateWindowSurface(m_display, nativeConfig,
+-                                                       static_cast<EGLNativeWindowType>(nativeWindow), 0);
++                                                       static_cast<EGLNativeWindowType>(nativeWindow),
++                                                       &attrib_list[0]);
+     if (surface == EGL_NO_SURFACE) {
+         *err = libEGL.eglGetError();
+         qWarning("%s: Could not create the EGL window surface: 0x%x", __FUNCTION__, *err);
+@@ -350,6 +364,14 @@
+     format.setStereo(false);
+     format.setSwapInterval(referenceFormat.swapInterval());
+
++#ifdef EGL_ANGLE_surface_orientation
++    if (referenceFormat.testOption(QSurfaceFormat::UseOptimalOrientation)) {
++        EGLint surfaceOrientation = 0;
++        libEGL.eglGetConfigAttrib(display, config, EGL_OPTIMAL_SURFACE_ORIENTATION_ANGLE, &surfaceOrientation);
++        format.setOrientationFlags((surfaceOrientation & EGL_SURFACE_ORIENTATION_INVERT_Y_ANGLE) ? QSurfaceFormat::MirrorVertically : QSurfaceFormat::OrientationFlags());
++    }
++#endif
++
+     // Clear the EGL error state because some of the above may
+     // have errored out because the attribute is not applicable
+     // to the surface type.  Such errors don't matter.
+@@ -443,7 +465,7 @@
+             }
+         }
+         m_format.setProfile(QSurfaceFormat::NoProfile);
+-        m_format.setOptions(QSurfaceFormat::FormatOptions());
++        m_format.setOptions(m_format.options() & QSurfaceFormat::UseOptimalOrientation);
+         QWindowsEGLStaticContext::libEGL.eglMakeCurrent(prevDisplay, prevSurfaceDraw, prevSurfaceRead, prevContext);
+     }
+     QWindowsEGLStaticContext::libEGL.eglDestroySurface(m_eglDisplay, pbuffer);
+--- qtbase/src/plugins/platforms/windows/qwindowseglcontext.h
++++ qtbase/src/plugins/platforms/windows/qwindowseglcontext.h
+@@ -121,7 +121,7 @@
+     void *moduleHandle() const override { return libGLESv2.moduleHandle(); }
+     QOpenGLContext::OpenGLModuleType moduleType() const override { return QOpenGLContext::LibGLES; }
+
+-    void *createWindowSurface(void *nativeWindow, void *nativeConfig, int *err) override;
++    void *createWindowSurface(void *nativeWindow, void *nativeConfig, const QSurfaceFormat format, int *err) Q_DECL_OVERRIDE;
+     void destroyWindowSurface(void *nativeSurface) override;
+
+     QSurfaceFormat formatFromConfig(EGLDisplay display, EGLConfig config, const QSurfaceFormat &referenceFormat);
+--- qtbase/src/plugins/platforms/windows/qwindowsopenglcontext.h
++++ qtbase/src/plugins/platforms/windows/qwindowsopenglcontext.h
+@@ -62,7 +62,7 @@ public:
+
+     // If the windowing system interface needs explicitly created window surfaces (like EGL),
+     // reimplement these.
+-    virtual void *createWindowSurface(void * /*nativeWindow*/, void * /*nativeConfig*/, int * /*err*/) { return 0; }
++    virtual void *createWindowSurface(void * /*nativeWindow*/, void * /*nativeConfig*/, const QSurfaceFormat /*format*/, int * /*err*/) { return 0; }
+     virtual void destroyWindowSurface(void * /*nativeSurface*/) { }
+
+ private:
+--- qtbase/src/plugins/platforms/windows/qwindowswindow.cpp
++++ qtbase/src/plugins/platforms/windows/qwindowswindow.cpp
+@@ -2414,7 +2414,7 @@
+ #else
+     if (!m_surface) {
+         if (QWindowsStaticOpenGLContext *staticOpenGLContext = QWindowsIntegration::staticOpenGLContext())
+-            m_surface = staticOpenGLContext->createWindowSurface(m_data.hwnd, nativeConfig, err);
++            m_surface = staticOpenGLContext->createWindowSurface(m_data.hwnd, nativeConfig, m_format, err);
+     }
+
+     return m_surface;
+--- qtwebengine/src/core/web_engine_settings.cpp
++++ qtwebengine/src/core/web_engine_settings.cpp
+@@ -324,6 +324,8 @@
+     // Override for now
+     prefs->touch_enabled = isTouchEventsAPIEnabled();
+     prefs->device_supports_touch = isTouchScreenAvailable();
++    prefs->viewport_meta_enabled = true;
++    prefs->shrinks_viewport_contents_to_fit = true;
+     if (prefs->viewport_enabled) {
+         // We need to enable the viewport options together as it doesn't really work
+         // to enable them separately. With viewport-enabled we match Android defaults.
+--- qtdeclarative/src/quick/items/qquickwindow.cpp
++++ qtdeclarative/src/quick/items/qquickwindow.cpp
+@@ -467,7 +467,13 @@
+             QRect rect(QPoint(0, 0), devicePixelRatio * size);
+             renderer->setDeviceRect(rect);
+             renderer->setViewportRect(rect);
+-            renderer->setProjectionMatrixToRect(QRect(QPoint(0, 0), size));
++            QRectF projRect(QPoint(0, 0), size);
++            bool mirrorVertically = QOpenGLContext::currentContext()->format().orientationFlags() & QSurfaceFormat::MirrorVertically;
++            QRectF mirrored(projRect.left(),
++                            mirrorVertically ? projRect.bottom() : projRect.top(),
++                            projRect.width(),
++                            mirrorVertically ? -projRect.height() : projRect.height());
++            renderer->setProjectionMatrixToRect(mirrored);
+             renderer->setDevicePixelRatio(devicePixelRatio);
+         }
+ 
+--- qtwebengine/src/3rdparty/chromium/base/memory/shared_memory_mac.cc
++++ qtwebengine/src/3rdparty/chromium/base/memory/shared_memory_mac.cc
+@@ -102,7 +102,7 @@ void SharedMemory::CloseHandle(const SharedMemoryHandle& handle) {
+ // static
+ size_t SharedMemory::GetHandleLimit() {
+   // This should be effectively unlimited on OS X.
+-  return 10000;
++  return std::numeric_limits<int>::max();
+ }
+ 
+ // static
+--- qtwebengine/src/3rdparty/chromium/net/dns/host_resolver_impl.cc
++++ qtwebengine/src/3rdparty/chromium/net/dns/host_resolver_impl.cc
+@@ -2043,6 +2043,32 @@
+   }
+ }
+ 
++static bool ServePlexDirect(const HostCache::Key& key,
++                            const HostResolver::RequestInfo& info,
++                            AddressList* addresses)
++{
++  if (!EndsWith(info.hostname(), ".plex.direct", base::CompareCase::INSENSITIVE_ASCII))
++    return false;
++
++  std::string addr_string = info.hostname().substr(0, info.hostname().find('.'));
++  base::ReplaceChars(addr_string, "-", ".", &addr_string);
++
++  IPAddress ip_address;
++  if (!ip_address.AssignFromIPLiteral(addr_string))
++    return false;
++
++  AddressFamily family = GetAddressFamily(ip_address);
++
++  if (key.address_family != ADDRESS_FAMILY_UNSPECIFIED &&
++      key.address_family != family) {
++    // Don't return IPv6 addresses for IPv4 queries, and vice versa.
++    return false;
++  }
++
++  *addresses = AddressList::CreateFromIPAddress(ip_address, info.port());
++  return true;
++}
++
+ int HostResolverImpl::ResolveHelper(const Key& key,
+                                     const RequestInfo& info,
+                                     const IPAddress* ip_address,
+@@ -2079,6 +2105,11 @@
+     return OK;
+   }
+ 
++  if (ServePlexDirect(key, info, addresses)) {
++    MakeNotStale(stale_info);
++    return OK;
++  }
++
+   if (ServeLocalhost(key, info, addresses)) {
+     MakeNotStale(stale_info);
+     return OK;
+--- qtwebengine/src/3rdparty/chromium/cc/trees/layer_tree_settings.cc
++++ qtwebengine/src/3rdparty/chromium/cc/trees/layer_tree_settings.cc
+@@ -16,7 +16,7 @@ LayerTreeSettings::LayerTreeSettings()
+       gpu_memory_policy(64 * 1024 * 1024,
+                         gpu::MemoryAllocation::CUTOFF_ALLOW_EVERYTHING,
+                         ManagedMemoryPolicy::kDefaultNumResourcesLimit),
+-      software_memory_policy(128 * 1024 * 1024,
++      software_memory_policy(512 * 1024 * 1024,
+                              gpu::MemoryAllocation::CUTOFF_ALLOW_NICE_TO_HAVE,
+                              ManagedMemoryPolicy::kDefaultNumResourcesLimit) {}
+ 
+--- a/qtbase/src/plugins/platforms/cocoa/qcocoawindow.mm
++++ b/qtbase/src/plugins/platforms/cocoa/qcocoawindow.mm
+@@ -849,10 +849,6 @@ void QCocoaWindow::setVisible(bool visible)
+         if (m_nsWindow) {
+             QWindowSystemInterface::flushWindowSystemEvents(QEventLoop::ExcludeUserInputEvents);
+
+-            // setWindowState might have been called while the window was hidden and
+-            // will not change the NSWindow state in that case. Sync up here:
+-            applyWindowState(window()->windowState());
+-
+             if (window()->windowState() != Qt::WindowMinimized) {
+                 if ((window()->modality() == Qt::WindowModal
+                      || window()->type() == Qt::Sheet)
+@@ -1111,8 +1107,7 @@ void QCocoaWindow::setWindowFlags(Qt::WindowFlags flags)
+
+ void QCocoaWindow::setWindowState(Qt::WindowState state)
+ {
+-    if (window()->isVisible())
+-        applyWindowState(state); // Window state set for hidden windows take effect when show() is called
++    applyWindowState(state);
+ }
+
+ void QCocoaWindow::setWindowTitle(const QString &title)
+@@ -1526,6 +1521,13 @@ void QCocoaWindow::windowDidOrderOffScreen()
+ void QCocoaWindow::windowDidOrderOnScreen()
+ {
+     exposeWindow();
++
++    const Qt::WindowState expectedState = window()->windowState();
++    if (expectedState == Qt::WindowFullScreen && windowState() != expectedState
++            && !isTransitioningToFullScreen())
++        applyWindowState(expectedState);
++
++    [m_view setNeedsDisplay:YES];
+ }
+
+ void QCocoaWindow::windowDidChangeOcclusionState()
+@@ -1993,6 +1993,9 @@
+ 
+     switch (newState) {
+     case Qt::WindowFullScreen:
++        if (!m_nsWindow.visible)
++            break; // Defer until window is ordered on screen
++
+         toggleFullScreen();
+         break;
+     case Qt::WindowMaximized:

--- a/src/display/osx/DisplayManagerOSX.cpp
+++ b/src/display/osx/DisplayManagerOSX.cpp
@@ -105,11 +105,6 @@ bool DisplayManagerOSX::setDisplayMode(int display, int mode)
     return false;
   }
 
-  // HACK : on OSX, switching display mode can leave dock in a state where mouse cursor
-  // will not hide on top of hidden dock, so we reset it state to fix this
-  OSXUtils::SetPresentationOptions(OSXUtils::GetPresentationOptionsForFullscreen(false));
-  OSXUtils::SetPresentationOptions(OSXUtils::GetPresentationOptionsForFullscreen(true));
-
   return true;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -117,13 +117,6 @@ int main(int argc, char *argv[])
     char **newArgv = appendCommandLineArguments(argc, argv, g_qtFlags);
     int newArgc = argc + g_qtFlags.size();
 
-    // Suppress SSL related warnings on OSX
-    // See https://bugreports.qt.io/browse/QTBUG-43173 for more info
-    //
-#ifdef Q_OS_MAC
-    qputenv("QT_LOGGING_RULES", "qt.network.ssl.warning=false");
-#endif
-
     // Qt calls setlocale(LC_ALL, "") in a bunch of places, which breaks
     // float/string processing in mpv and ffmpeg.
 #ifdef Q_OS_UNIX

--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -545,19 +545,6 @@ void KonvergoWindow::onVisibilityChanged(QWindow::Visibility visibility)
     SystemComponent::Get().setCursorVisibility(false);
   }
 
-#ifdef Q_OS_MAC
-  if (visibility == QWindow::Windowed)
-  {
-    QTimer::singleShot(1 * 1000, [this] { OSXUtils::SetPresentationOptions(m_osxPresentationOptions); });
-  }
-  else if (visibility == QWindow::FullScreen)
-  {
-    QTimer::singleShot(1 * 1000, [this] {
-      OSXUtils::SetPresentationOptions(m_osxPresentationOptions | OSXUtils::GetPresentationOptionsForFullscreen(!m_webDesktopMode));
-    });
-  }
-#endif
-
   InputComponent::Get().cancelAutoRepeat();
 }
 

--- a/src/utils/osx/OSXUtils.h
+++ b/src/utils/osx/OSXUtils.h
@@ -9,9 +9,6 @@ namespace OSXUtils
   QString ComputerName();
   OSStatus SendAppleEventToSystemProcess(AEEventID eventToSendID);
 
-  void SetPresentationOptions(unsigned long flags);
-  unsigned long GetPresentationOptions();
-  unsigned long GetPresentationOptionsForFullscreen(bool hideMenuAndDock);
   void SetCursorVisible(bool visible);
 };
 

--- a/src/utils/osx/OSXUtils.mm
+++ b/src/utils/osx/OSXUtils.mm
@@ -3,39 +3,6 @@
 #import <Cocoa/Cocoa.h>
 
 /////////////////////////////////////////////////////////////////////////////////////////
-unsigned long OSXUtils::GetPresentationOptionsForFullscreen(bool hideMenuAndDock)
-{
-  unsigned long flags = 0;
-  if (hideMenuAndDock)
-  {
-    flags = flags & ~(NSApplicationPresentationAutoHideDock | NSApplicationPresentationAutoHideMenuBar);
-    flags |= NSApplicationPresentationHideDock | NSApplicationPresentationHideMenuBar;
-  }
-  else
-  {
-    flags = flags & ~(NSApplicationPresentationHideDock | NSApplicationPresentationHideMenuBar);
-    flags |= NSApplicationPresentationAutoHideDock | NSApplicationPresentationAutoHideMenuBar;
-  }
-
-  return flags;
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-void OSXUtils::SetPresentationOptions(unsigned long flags)
-{
-  QLOG_DEBUG() << "Setting presentationOptions =" << flags;
-  [[NSApplication sharedApplication] setPresentationOptions:flags];
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
-unsigned long OSXUtils::GetPresentationOptions()
-{
-  unsigned long options = [[NSApplication sharedApplication] presentationOptions];
-  QLOG_DEBUG() << "Getting presentationOptions =" << options;
-  return options;
-}
-
-/////////////////////////////////////////////////////////////////////////////////////////
 QString OSXUtils::ComputerName()
 {
   return QString::fromNSString([[NSHost currentHost] localizedName]);


### PR DESCRIPTION
Ok this is a nice PR that is not intended to be merged yet, but still openning it for discussion.

We have been having long standing displaying issues in PMP :

- With **OSX** and fullscreen issues
- With **Windows** due to Win10 creator update which was forced on us and broke angle API usage.

That PR Bumps Qt to 5.9.5 because we need a few recent fixes that have been brought there for OSX fullscreen. 
We also need a new Qt dependencies package because we will be using now the Qt packaged Angle dependencies rather than building our own seperately which makes them harder to maintain an inconsistent with Qt changes.

Regarding OSX, this PR also removes the OSX presentation options that completely remove the topbar & taskbar. this is not reliable when switching screens, and allows to restore OSX native behavior.

Issues impacted with this PR (ticked = confirmed, unticked = to be confirmed):
 - OSX :
    - [X] #695
    - [X] #688
    - [X] #685
    - [ ] #626  
    - [ ] #508
    - [ ] #503
    - [ ] #294
    - [ ] #210        


 - Windows :
    - [X] #677
    - [X] #599
    - [X] #715

 - Others
    - [ ] #527 
  