### PR TITLE
Make Qt versions in README.md consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Assuming that everything else has installed correctly, building Plex Media Playe
 * ``cd plex-media-player``
 * ``mkdir build``
 * ``cd build``
-* ``cmake -DCMAKE_BUILD_TYPE=Debug -DQTROOT=/opt/Qt5.6.1/5.6/gcc_64/ -DCMAKE_INSTALL_PREFIX=/usr/local/ ..``
+* ``cmake -DCMAKE_BUILD_TYPE=Debug -DQTROOT=/opt/Qt5.9.5/5.9/gcc_64/ -DCMAKE_INSTALL_PREFIX=/usr/local/ ..``
 * ``make -j4``
 * ``sudo make install``
 


### PR DESCRIPTION
Just a minor change to be consistent after a8d4578.