### PR TITLE
Display Rate Fixes

### DIFF
--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -85,11 +85,12 @@ bool DisplayManager::isRateMultipleOf(float refresh, float multiple, bool exact)
   if (roundedRefresh == 0)
       return false;
 
-  float newRate = roundedMultiple / roundedRefresh * refresh;
+  long factor = roundedMultiple / roundedRefresh;
+  float newRate = factor * refresh;
   if (newRate < 1)
     return false;
 
-  float tolerance = exact ? 0.1 : 1;
+  float tolerance = exact ? 0.01 * factor : 1;
 
   return fabs(newRate - multiple) < tolerance;
 }


### PR DESCRIPTION
Rationale:
- Have a TV that supports both 59.94Hz and 60Hz display rates
- Have display currently on 60Hz
- Play content that is 29.97Hz
- Prior to this change, the 60Hz rate was within 0.1Hz of 2*29.97Hz so it would be deemed an exact multiple match and content would play at 60Hz
- After this change, 59.94Hz would be deemed an exact multiple match (properly) and 60Hz would be deemed a close multiple match (properly).
- This change also mirrors the exact match logic which uses a tolerance of 0.01 where as the multiple match was previously using a tolerance of 0.1.  Since there is a multiplicative factor involved in this function, I multiplied 0.01 by that factor to achieve the final tolerance.