### PR TITLE
Improve systemname handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ web-client
 .DS_Store
 .*libreelec*
 toolchain.cmake
+.sublime-settings


### PR DESCRIPTION
### Context

Our `systemname` setting was ignored on desktop systems. Reported [in the forums](https://forums.plex.tv/t/for-the-love-of-god-can-you-please-let-me-change-name-of-pmp/278708/).

@sixones tagging you on this to make sure the C++ is sane.

- Fixes #762 

### Discussion

Please see the comments included in the code for context and solution.

Although even after this change there's another bug, this time in PMS, which results in the Plex player drop down in Web displaying stale player names. Several PMS restarts seems to cause the correct name to be displayed.

### Steps to test

I've included debug logs to keep this testable. I haven't been able to test on embedded although realistically testing on desktop will cover both desktop and embedded environments.

I've tested:

* Shutdown PMP
* Edit `plexmediaplayer.conf` to include `systemname: "PlexMediaPlayer"` -- the default value
* Startup PMP and tail logs
* You should see the host select the system's hostname as the resource title:
```
2018-07-03 15:02:42 [ DEBUG ] RemoteComponent.cpp @ 106 - Resolving system name: Host name: "Matt_s MacBook Pro" 
2018-07-03 15:02:42 [ DEBUG ] RemoteComponent.cpp @ 107 - Resolving system name: System name setting: "PlexMediaPlayer" 
2018-07-03 15:02:42 [ DEBUG ] RemoteComponent.cpp @ 108 - Resolving system name: Is system name setting empty value: 0 
2018-07-03 15:02:42 [ DEBUG ] RemoteComponent.cpp @ 109 - Resolving system name: Is system name setting default value: 1 
2018-07-03 15:02:42 [ DEBUG ] RemoteComponent.cpp @ 110 - Resolving system name: Final value: "Matt_s MacBook Pro" 
```

* Shutdown PMP
* Edit `plexmediaplayer.conf` to include `systemname: "Something custom"` -- anything but the default value
* Startup PMP and tail logs
* You should see the host select the `systemname` setting as the resource title:
```
2018-07-03 15:05:00 [ DEBUG ] RemoteComponent.cpp @ 108 - Resolving system name: Host name: "Matt_s MacBook Pro" 
2018-07-03 15:05:00 [ DEBUG ] RemoteComponent.cpp @ 109 - Resolving system name: System name setting: "Office Display" 
2018-07-03 15:05:00 [ DEBUG ] RemoteComponent.cpp @ 110 - Resolving system name: Is system name setting empty value: 0 
2018-07-03 15:05:00 [ DEBUG ] RemoteComponent.cpp @ 111 - Resolving system name: Is system name setting default value: 0 
2018-07-03 15:05:00 [ DEBUG ] RemoteComponent.cpp @ 112 - Resolving system name: Final value: "Office Display" 
```