### PR TITLE
Fix window icon on Linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -158,9 +158,8 @@ int main(int argc, char *argv[])
       qputenv("QT_SCALE_FACTOR", scale.toUtf8());
 
     QApplication app(newArgc, newArgv);
-#ifdef Q_OS_WIN
-    // Setting the icon on Windows is necessary but will break user
-    // ability to change icon on OSX
+#if defined(Q_OS_WIN) || defined(Q_OS_LINUX)
+    // Setting window icon on OSX will break user ability to change it
     app.setWindowIcon(QIcon(":/images/icon.png"));
 #endif
 


### PR DESCRIPTION
Fix for #788 
Use Plex icon with window manager on Linux.

![pmp_plex_icon](https://user-images.githubusercontent.com/2482753/47191613-b7d38980-d348-11e8-8a2f-f5b5136e0b31.png)

