### PR TITLE
Update issue template to help users frame issues concisely

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,22 +1,32 @@
-## How to file an issue - REMOVE THIS SECTION
- - Add a prefix to the title scoping the issue, e.g. `gui: `, `player: ` ... 
- - use a title that is clear enough
- - If appropriate, add a topic label to group the issue with a larger effort and allow filtering by that topic.
+<!--
+PLEASE REMOVE THIS SECTION
 
-## How to file a bug - REMOVE THIS LINE
+This repository is only for Plex Media Player (PMP). Please do not open issues related to other Plex clients (Roku, Apple TV, etc) or Plex Media Server.
+
+Each filed issue must please:
+
+  - include a concise description of the issue and steps to reproduce.
+  - include a sample media file or media file information when applicable.
+    - Generating samples: https://support.plex.tv/articles/201035968-generating-sample-files-from-media/.
+    - Retrieving XML media information: https://support.plex.tv/articles/201998867-investigate-media-information-and-formats/. Please attach within zip.
+  - be accompanied by _clean_ logs.
+    - PMP logs can be found here: https://support.plex.tv/articles/207338748-plex-media-player-logs/
+    - Clean log instructions: Clear your logs; reproduce the issue; attach logs in a .zip file.
+
+PLEASE REMOVE THIS SECTION
+-->
 
 ### Test environment
+
 **PMS Version:**
 **PMP Version:**
-**Platform (Windows/OSX/Embedded):**
+**Platform (Windows/macOS/Embedded RPi/Embedded Intel):**
 
 ### Steps to reproduce
 1.
 
 ### Current behavior
-<!-- What is happening?  -->
 1.
 
 ### Expected behavior
-<!-- What should happen?  -->
 1.


### PR DESCRIPTION
We receive a ~steady drip of issues in this repository for other Plex players and sometimes Plex Media Server.

Let's update the issue template to help issue submitters identify if their issue is appropriate for this repository. Let's also ask our issue submitters to help us better understand and reproduce their observations.

Look good? See any thing we can improve?