### PR TITLE
player: Add path to ca-bundle on SUSE

### DIFF
--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -138,7 +138,8 @@ bool PlayerComponent::componentInitialize()
        << "/usr/local/share/certs/ca-root-nss.crt"
        << "/etc/ssl/cert.pem"
        << "/usr/share/curl/curl-ca-bundle.crt"
-       << "/usr/local/share/curl/curl-ca-bundle.crt";
+       << "/usr/local/share/curl/curl-ca-bundle.crt"
+       << "/var/lib/ca-certificates/ca-bundle.pem";
 
   bool success = false;
 


### PR DESCRIPTION
On SUSE, ca-bundle is stored in /var.
Without this patch, PMP fails to start with "Failed to locate CA bundle" unless
it gets linked by the user into one of the known paths

Signed-off-by: Nicolas Morey-Chaisemartin <nmoreychaisemartin@suse.com>