### PR TITLE
GTK dark titlebar

### DIFF
--- a/src/ui/KonvergoWindow.cpp
+++ b/src/ui/KonvergoWindow.cpp
@@ -21,6 +21,11 @@
 #include "Globals.h"
 #include "EventFilter.h"
 
+#ifdef Q_OS_UNIX
+#include <QX11Info>
+#include <X11/Xlib.h> 
+#endif
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 class ScopedDecrementer
 {
@@ -66,6 +71,22 @@ KonvergoWindow::KonvergoWindow(QWindow* parent) :
   setColor(QColor("transparent"));
 #else
   setColor(QColor("#000000"));
+#endif
+ 
+#ifdef Q_OS_UNIX
+  // On Gnome show a darker title bar
+  if (QX11Info::isPlatformX11())
+  {
+    Display* dpy = QX11Info::display();
+    if (dpy)
+    {
+      WId win = winId();
+      XChangeProperty(dpy, win,
+                      XInternAtom(dpy, "_GTK_THEME_VARIANT", false),
+                      XInternAtom(dpy, "UTF8_STRING", false),
+                      8, PropModeReplace, (unsigned char *) "dark", 4);
+    }
+  }
 #endif
 
   QRect loadedGeo = loadGeometry();


### PR DESCRIPTION
Set X11 Window Property for GTK darker titlebar. This pure cosmetic
patch makes the titlebar less intrusive when using the player in
windowed mode.

Plex-CLA-1.0-signed-off-by: Max Resch <resch.max@gmail.com>