### PR TITLE
Change default webMode to "tv"

### DIFF
--- a/resources/settings/settings_description.json
+++ b/resources/settings/settings_description.json
@@ -20,7 +20,7 @@
     "values": [
       {
         "value": "webMode",
-        "default": "desktop",
+        "default": "tv",
         "hidden": true,
         "platforms": [ "windows", "macosx" ],
         "possible_values": [


### PR DESCRIPTION
This PR changes the default layout to "tv", from Desktop. This change has already been made in our v3 preview builds.

### Expected behavior

Previous to this change the default webMode was "desktop". On first run PMP creates `plexmediaplayer.conf` using the configuration defined in `settings_description.json`. With this in mind any PMP installations which have been run at least once will experience no change to the layout displayed on last run.

Existing installations, once updated to a version with this change, will change their `webMode` when one of the following happens:

- delete `plexmediaplayer.conf`
- reset `webMode` to default - `SettingsComponent::resetToDefault`
- reset all settings to default - `SettingsComponent::resetToDefaultAll`

Fresh installations not covered above will default `webMode` to "desktop".

### Steps to test

- Download and run the 2.5.3 release.
    - Change to Desktop mode using UI.
- Exit 2.5.3
- Run the test build of this branch.
    - The app should remain in Desktop mode.
- Exit test build
- Delete `plexmediaplayer.conf` - `~/Library/Application\ Support/Plex\ Media\ Player/plexmediaplayer.conf`
- Run test build
- App should launch in TV mode.