### PR TITLE
Update plexmediaplayer.desktop

### DIFF
--- a/resources/desktop/plexmediaplayer.desktop
+++ b/resources/desktop/plexmediaplayer.desktop
@@ -3,17 +3,21 @@ Version=1.0
 Name=Plex Media Player
 GenericName=Media Player
 Comment=View your media
-Exec=plexmediaplayer --fullscreen --tv
+Exec=plexmediaplayer
 Icon=plexmediaplayer
 Terminal=false
 Type=Application
 Categories=AudioVideo;Video;Player;TV;
 
-Actions=TV;DesktopF;DesktopW;
+Actions=TVF;TVW;DesktopF;DesktopW;
 
-[Desktop Action TV]
-Name=TV
+[Desktop Action TVF]
+Name=TV [Fullscreen]
 Exec=plexmediaplayer --fullscreen --tv
+
+[Desktop Action TVW]
+Name=TV [Windowed]
+Exec=plexmediaplayer --windowed --tv
 
 [Desktop Action DesktopF]
 Name=Desktop [Fullscreen]


### PR DESCRIPTION
Default behavior should be to auto save the last used layout.
 --fullscreen --tv breaks that functionality and forces the fullscreen TV layout on all users every start.

Plex-CLA-1.0-signed-off-by: Manuel Rusch manuel.rusch@gmail.com