### PR TITLE
Kill the helper on shutdown/reboot.

### DIFF
--- a/src/power/PowerComponentDBus.cpp
+++ b/src/power/PowerComponentDBus.cpp
@@ -3,6 +3,7 @@
 #include <QtDBus/QDBusReply>
 
 #include "PowerComponentDBus.h"
+#include "utils/HelperLauncher.h"
 
 #define DBUS_SERVICE_NAME "org.freedesktop.login1"
 #define DBUS_SERVICE_PATH "/org/freedesktop/login1"
@@ -11,6 +12,20 @@
 #define DBUS_SCREENSAVER_SERVICE_NAME "org.freedesktop.ScreenSaver"
 #define DBUS_SCREENSAVER_SERVICE_PATH "/org/freedesktop/ScreenSaver"
 #define DBUS_SCREENSAVER_INTERFACE "org.freedesktop.ScreenSaver"
+
+/////////////////////////////////////////////////////////////////////////////////////////
+bool PowerComponentDBus::PowerOff()
+{
+  HelperLauncher::Get().stop();
+  return callPowerMethod("PowerOff");
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////
+bool PowerComponentDBus::Reboot()
+{
+  HelperLauncher::Get().stop();
+  return callPowerMethod("Reboot");
+}
 
 /////////////////////////////////////////////////////////////////////////////////////////
 bool PowerComponentDBus::callPowerMethod(QString method)

--- a/src/power/PowerComponentDBus.h
+++ b/src/power/PowerComponentDBus.h
@@ -23,8 +23,8 @@ class PowerComponentDBus : public PowerComponent
     return flags;
   }
 
-    virtual bool PowerOff() { return callPowerMethod("PowerOff"); }
-    virtual bool Reboot() { return callPowerMethod("Reboot"); }
+    virtual bool PowerOff();
+    virtual bool Reboot();
     virtual bool Suspend() { return callPowerMethod("Suspend"); }
 
   private:


### PR DESCRIPTION
On linux systems, when the shutdown or reboot is triggered from PMP, the helper can suspend the shutdown/reboot process for 90s (default) while the OS is waiting for it to quit and not doing so.  This kills the helper before we get there and thus enabling a much faster shutdown/reboot in those circumstances.