### PR TITLE
Fix method invocation ambiguity

### DIFF
--- a/src/player/CodecsComponent.cpp
+++ b/src/player/CodecsComponent.cpp
@@ -685,9 +685,9 @@ static Downloader::HeaderList getPlexHeaders()
   Downloader::HeaderList headers;
   QString auth = SystemComponent::Get().authenticationToken();
   if (auth.size())
-    headers.append({"X-Plex-Token", auth});
-  headers.append({"X-Plex-Product", WITH_CODECS ? "Plex Media Player" : "openpmp"});
-  headers.append({"X-Plex-Platform", "Konvergo"});
+    headers.append(Downloader::Header{"X-Plex-Token", auth});
+  headers.append(Downloader::Header{"X-Plex-Product", WITH_CODECS ? "Plex Media Player" : "openpmp"});
+  headers.append(Downloader::Header{"X-Plex-Platform", "Konvergo"});
   return headers;
 }
 

--- a/src/player/CodecsComponent.h
+++ b/src/player/CodecsComponent.h
@@ -75,7 +75,8 @@ class Downloader : public QObject
 {
   Q_OBJECT
 public:
-  typedef QList<QPair<QString, QString>> HeaderList;
+  typedef QPair<QString, QString> Header;
+  typedef QList<Header> HeaderList;
   explicit Downloader(QVariant userData, const QUrl& url, const HeaderList& headers, QObject* parent);
 Q_SIGNALS:
   void done(QVariant userData, bool success, const QByteArray& data);


### PR DESCRIPTION
This fixes 

```
/usr/include/qt5/QtCore/qlist.h:210:10: note: candidate function
    void append(const T &t);
         ^
/usr/include/qt5/QtCore/qlist.h:211:10: note: candidate function
    void append(const QList<T> &t);
```

with my Qt and compiler version. 
