### PR TITLE
Mac OS dark mode support

### DIFF
--- a/bundle/osx/Info.plist.in
+++ b/bundle/osx/Info.plist.in
@@ -34,6 +34,8 @@
 	<string>NSApplication</string>
 	<key>NSHighResolutionCapable</key>
 	<string>True</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>False</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>10.9</string>
 	<key>NSSupportsAutomaticGraphicsSwitching</key>


### PR DESCRIPTION
This will allow the title bar to turn dark in Mac OS with enabled dark mode.