### PR TITLE
player: replaces opengl-cb with the libmpv Render API

### DIFF
--- a/src/player/PlayerComponent.cpp
+++ b/src/player/PlayerComponent.cpp
@@ -259,7 +259,7 @@ void PlayerComponent::setQtQuickWindow(QQuickWindow* window)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void PlayerComponent::setWindow(QQuickWindow* window)
 {
-  QString vo = "opengl-cb";
+  QString vo = "libmpv";
 
 #ifdef TARGET_RPI
   window->setFlags(Qt::FramelessWindowHint);
@@ -276,7 +276,7 @@ void PlayerComponent::setWindow(QQuickWindow* window)
 
   mpv::qt::set_property(m_mpv, "vo", vo);
 
-  if (vo == "opengl-cb")
+  if (vo == "libmpv")
     setQtQuickWindow(window);
 }
 

--- a/src/player/PlayerQuickItem.cpp
+++ b/src/player/PlayerQuickItem.cpp
@@ -113,7 +113,7 @@ bool PlayerRenderer::init()
       .get_proc_address = get_proc_address,
       .get_proc_address_ctx = NULL,
       .extra_exts = extensions,
-  }; 
+  };
   mpv_render_param params[] = {
     {MPV_RENDER_PARAM_API_TYPE, (void*)MPV_RENDER_API_TYPE_OPENGL},
     {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &opengl_params},

--- a/src/player/PlayerQuickItem.cpp
+++ b/src/player/PlayerQuickItem.cpp
@@ -11,6 +11,8 @@
 #include <QtQuick/QQuickWindow>
 #include <QOpenGLFunctions>
 
+#include <mpv/render_gl.h>
+
 #include "QsLog.h"
 #include "utils/Utils.h"
 
@@ -93,7 +95,6 @@ private:
 PlayerRenderer::PlayerRenderer(mpv::qt::Handle mpv, QQuickWindow* window)
 : m_mpv(mpv), m_mpvGL(nullptr), m_window(window), m_size(), m_hAvrtHandle(nullptr), m_videoRectangle(-1, -1, -1, -1), m_fbo(0)
 {
-  m_mpvGL = (mpv_opengl_cb_context *)mpv_get_sub_api(m_mpv, MPV_SUB_API_OPENGL_CB);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -104,11 +105,27 @@ bool PlayerRenderer::init()
   DwmEnableMMCSS(TRUE);
 #endif
 
-  mpv_opengl_cb_set_update_callback(m_mpvGL, on_update, (void *)this);
 
   // Signals presence of MPGetNativeDisplay().
   const char *extensions = "GL_MP_MPGetNativeDisplay";
-  return mpv_opengl_cb_init_gl(m_mpvGL, extensions, get_proc_address, nullptr) >= 0;
+
+  mpv_opengl_init_params opengl_params = {
+      .get_proc_address = get_proc_address,
+      .get_proc_address_ctx = NULL,
+      .extra_exts = extensions,
+  }; 
+  mpv_render_param params[] = {
+    {MPV_RENDER_PARAM_API_TYPE, (void*)MPV_RENDER_API_TYPE_OPENGL},
+    {MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &opengl_params},
+    {MPV_RENDER_PARAM_INVALID},
+  };
+  int err = mpv_render_context_create(&m_mpvGL, m_mpv, params);
+
+  if (err >= 0) {
+    mpv_render_context_set_update_callback(m_mpvGL, on_update, (void *)this);
+    return true;
+  }
+  return false;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -116,7 +133,8 @@ PlayerRenderer::~PlayerRenderer()
 {
   // Keep in mind that the m_mpv handle must be held until this is done.
   if (m_mpvGL)
-    mpv_opengl_cb_uninit_gl(m_mpvGL);
+    mpv_render_context_free(m_mpvGL);
+  m_mpvGL = nullptr;
   delete m_fbo;
 }
 
@@ -158,9 +176,18 @@ void PlayerRenderer::render()
     }
   }
 
-  // The negative height signals to mpv that the video should be flipped
-  // (according to the flipped OpenGL coordinate system).
-  mpv_opengl_cb_draw(m_mpvGL, fbo, fboSize.width(), (flip ? -1 : 1) * fboSize.height());
+  mpv_opengl_fbo mpv_fbo = {
+    .fbo = fbo,
+    .w = fboSize.width(),
+    .h = fboSize.height(),
+  };
+  int mpv_flip = flip ? -1 : 0;
+  mpv_render_param params[] = {
+    {MPV_RENDER_PARAM_OPENGL_FBO, &mpv_fbo},
+    {MPV_RENDER_PARAM_FLIP_Y, &mpv_flip},
+    {MPV_RENDER_PARAM_INVALID}
+  };
+  mpv_render_context_render(m_mpvGL, params);
 
   m_window->resetOpenGLState();
 
@@ -177,7 +204,8 @@ void PlayerRenderer::render()
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 void PlayerRenderer::swap()
 {
-  mpv_opengl_cb_report_flip(m_mpvGL, 0);
+  if (m_mpvGL)
+    mpv_render_context_report_swap(m_mpvGL);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -224,7 +252,7 @@ PlayerQuickItem::PlayerQuickItem(QQuickItem* parent)
 PlayerQuickItem::~PlayerQuickItem()
 {
   if (m_mpvGL)
-    mpv_opengl_cb_set_update_callback(m_mpvGL, nullptr, nullptr);
+    mpv_render_context_set_update_callback(m_mpvGL, nullptr, nullptr);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -297,10 +325,6 @@ void PlayerQuickItem::onInvalidate()
 void PlayerQuickItem::initMpv(PlayerComponent* player)
 {
   m_mpv = player->getMpvHandle();
-
-  m_mpvGL = (mpv_opengl_cb_context *)mpv_get_sub_api(m_mpv, MPV_SUB_API_OPENGL_CB);
-  if (!m_mpvGL)
-    throw FatalException(tr("OpenGL not enabled in libmpv."));
 
   connect(player, &PlayerComponent::windowVisible, this, &QQuickItem::setVisible);
   window()->update();

--- a/src/player/PlayerQuickItem.h
+++ b/src/player/PlayerQuickItem.h
@@ -6,7 +6,7 @@
 #include <QOpenGLFramebufferObject>
 
 #include <mpv/client.h>
-#include <mpv/opengl_cb.h>
+#include <mpv/render.h>
 
 #ifdef Q_OS_WIN32
 #include <windows.h>
@@ -34,7 +34,7 @@ public slots:
 private:
   static void on_update(void *ctx);
   mpv::qt::Handle m_mpv;
-  mpv_opengl_cb_context* m_mpvGL;
+  mpv_render_context* m_mpvGL;
   QQuickWindow* m_window;
   QSize m_size;
   HANDLE m_hAvrtHandle;
@@ -64,7 +64,7 @@ private slots:
 
 private:
     mpv::qt::Handle m_mpv;
-    mpv_opengl_cb_context* m_mpvGL;
+    mpv_render_context* m_mpvGL;
     PlayerRenderer* m_renderer;
     QString m_debugInfo;
 };


### PR DESCRIPTION
mpv 0.33 removes compatibility for the deprecated opengl-cb API. This change removes usages of opengl-cb and migrates to libmpv's Render API, as prescribed by mpv's developers.

This fixes the segmentation fault reported in #997.