### PR TITLE
[RFC] InputCEC activateSource on receivedInput

### DIFF
--- a/src/input/InputCEC.cpp
+++ b/src/input/InputCEC.cpp
@@ -67,6 +67,12 @@ bool InputCEC::initInput()
   return retVal;
 }
 
+//////////////////////////////////////////////////////////////////////////////////////////////////
+void InputCEC::activateSource()
+{
+  QMetaObject::invokeMethod(m_cecWorker, "activateSource", Qt::QueuedConnection);
+}
+
 /////////////////////////////////////////////////////////////////////////////////////////
 InputCEC::~InputCEC()
 {
@@ -117,6 +123,9 @@ bool InputCECWorker::init()
 
   // check for attached adapters
   checkAdapter();
+
+  // if necessary, wake device(s)
+  activateSource();
 
   // Start a timer to keep track of attached/removed adapters
   m_timer = new QTimer(nullptr);
@@ -184,12 +193,26 @@ void InputCECWorker::closeAdapter()
 void InputCECWorker::checkAdapter()
 {
   if (m_adapterPort.isEmpty())
-  {    
+  {
     if (m_adapter)
       m_adapter->Close();
 
     openAdapter();
   }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+void InputCECWorker::activateSource()
+{
+  if (!SettingsComponent::Get().value(SETTINGS_SECTION_CEC, "activatesource").toBool())
+  {
+    return;
+  }
+
+  // Check if a tv has powered on
+  QLOG_INFO() << "CEC activateSource changing input";
+  m_adapter->SetActiveSource();
+
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/input/InputCEC.h
+++ b/src/input/InputCEC.h
@@ -17,6 +17,8 @@ class InputCECWorker;
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 class InputCEC : public InputBase
 {
+    Q_OBJECT
+
 public:
   explicit InputCEC(QObject* parent);
   ~InputCEC();
@@ -24,6 +26,8 @@ public:
   const char* inputName() override { return CEC_INPUT_NAME; }
   bool initInput() override;
 
+public slots:
+    void activateSource();
 
 private:
   QThread* m_cecThread;
@@ -42,6 +46,7 @@ public:
   Q_SLOT bool init();
   Q_SIGNAL void receivedInput(const QString& source, const QString& keycode, InputBase::InputkeyState keyState);
   Q_SLOT void closeCec();
+  Q_SLOT void activateSource();
 
 public slots:
   void checkAdapter();

--- a/src/input/InputComponent.cpp
+++ b/src/input/InputComponent.cpp
@@ -99,7 +99,12 @@ bool InputComponent::componentInitialize()
 #endif
 #ifdef HAVE_CEC
   if (SettingsComponent::Get().value(SETTINGS_SECTION_CEC, "enable").toBool())
-    addInput(new InputCEC(this));
+  {
+    InputCEC* cec = new InputCEC(this);
+    addInput(cec);
+    connect(&InputKeyboard::Get(), &InputKeyboard::receivedInput,
+            cec, &InputCEC::activateSource);
+  }
 #endif
 
   return true;


### PR DESCRIPTION
My long term goal can be described as two separate features:
1. When Plex Media Player activates the screensaver, all CEC devices (Receiver/Soundbar, Projector/TV) power off to save energy
2. When Plex Media Player deactivates the screensaver (eg, by keyboard or remote input) all CEC devices power on and the inputs are changed if necessary

This pull request is a first attempt at accomplishing device power on.

My first goal here was to connect it to the PowerComponent screenSaverEnabled and screenSaverDisabled signals, but the comments in PowerComenent.h seem to indicate that those are deprecated and not funcitonal.

Without having those to rely on, I have instead connected the activateSource method to keyboard input. This is suboptimal because we're flooding the CEC devices with unnecessary signals on every keystroke.

I wanted to get the discussion rolling on how to implement this. Is there any upcoming replacement for the screensaver signals that I could connect this to instead?

I look forward to your feedback.